### PR TITLE
Effect refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,10 +214,10 @@ set(SOURCES
         Internal/Vulkan/VulkanCore/Pipeline/VRayTracingPipeline.hpp
         Internal/Vulkan/VulkanCore/Shader/VRayTracingShaders.cpp
         Internal/Vulkan/VulkanCore/Shader/VRayTracingShaders.hpp
-        Internal/Vulkan/Utils/VEffect/VGraphicsEffect.cpp
-        Internal/Vulkan/Utils/VEffect/VGraphicsEffect.hpp
         Internal/Vulkan/Utils/VEffect/VRayTracingEffect.cpp
         Internal/Vulkan/Utils/VEffect/VRayTracingEffect.hpp
+        Internal/Vulkan/Utils/VEffect/VEffect.cpp
+        Internal/Vulkan/Utils/VEffect/VEffect.hpp
 
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,8 +183,8 @@ set(SOURCES
         Internal/Editor/EditorOptions.hpp
         Internal/Vulkan/Utils/VResrouceGroup/VDescriptorSetStructs.hpp
         Internal/Vulkan/Utils/VResrouceGroup/VResrouceGroup.hpp
-        Internal/Vulkan/Utils/VEffect/VEffect.cpp
-        Internal/Vulkan/Utils/VEffect/VEffect.hpp
+        Internal/Vulkan/Utils/VEffect/VRasterEffect.cpp
+        Internal/Vulkan/Utils/VEffect/VRasterEffect.hpp
         Internal/Vulkan/Utils/VResrouceGroup/VResrouceGroup.cpp
         Internal/Application/AssetsManger/EffectsLibrary/EffectsLibrary.cpp
         Internal/Application/AssetsManger/EffectsLibrary/EffectsLibrary.hpp
@@ -214,6 +214,10 @@ set(SOURCES
         Internal/Vulkan/VulkanCore/Pipeline/VRayTracingPipeline.hpp
         Internal/Vulkan/VulkanCore/Shader/VRayTracingShaders.cpp
         Internal/Vulkan/VulkanCore/Shader/VRayTracingShaders.hpp
+        Internal/Vulkan/Utils/VEffect/VGraphicsEffect.cpp
+        Internal/Vulkan/Utils/VEffect/VGraphicsEffect.hpp
+        Internal/Vulkan/Utils/VEffect/VRayTracingEffect.cpp
+        Internal/Vulkan/Utils/VEffect/VRayTracingEffect.hpp
 
 )
 

--- a/Internal/Application/AssetsManger/AssetsManager.cpp
+++ b/Internal/Application/AssetsManger/AssetsManager.cpp
@@ -224,7 +224,7 @@ const std::vector<std::shared_ptr<ApplicationCore::SkyBoxMaterial>>& AssetsManag
     return m_skyBoxMaterials;
 }
 
-std::map<EEffectType, std::shared_ptr<VulkanUtils::VEffect>> AssetsManager::GetEffects() const
+std::map<EEffectType, std::shared_ptr<VulkanUtils::VRasterEffect>> AssetsManager::GetEffects() const
 {
     return m_effectsLibrary.effects;
 }

--- a/Internal/Application/AssetsManger/AssetsManager.cpp
+++ b/Internal/Application/AssetsManger/AssetsManager.cpp
@@ -301,11 +301,11 @@ void AssetsManager::
 
     MaterialPaths paths{};
     m_dummyMaterial =
-        std::make_shared<ApplicationCore::PBRMaterial>(m_effectsLibrary.GetEffect(EEffectType::ForwardShader), paths, *this);
+        std::make_shared<ApplicationCore::PBRMaterial>(m_effectsLibrary.GetEffect<VulkanUtils::VRasterEffect>(EEffectType::ForwardShader), paths, *this);
 
     MaterialPaths directionalLightBillboard{};
     directionalLightBillboard.DiffuseMapPath = "Resources/EditorIcons/light-directional.png";
-    auto mat = std::make_shared<ApplicationCore::PBRMaterial>(m_effectsLibrary.GetEffect(EEffectType::EditorBilboard),
+    auto mat = std::make_shared<ApplicationCore::PBRMaterial>(m_effectsLibrary.GetEffect<VulkanUtils::VRasterEffect>(EEffectType::EditorBilboard),
                                                               directionalLightBillboard, *this);
     mat->SetMaterialname("Directional light editor billboard");
     m_editorIconsMaterials[EEditorIcon::DirectionalLight] = mat;
@@ -313,14 +313,14 @@ void AssetsManager::
     MaterialPaths pointLightBillboard{};
     pointLightBillboard.DiffuseMapPath = "Resources/EditorIcons/light-point.png";
 
-    mat = std::make_shared<ApplicationCore::PBRMaterial>(m_effectsLibrary.GetEffect(EEffectType::EditorBilboard),
+    mat = std::make_shared<ApplicationCore::PBRMaterial>(m_effectsLibrary.GetEffect<VulkanUtils::VRasterEffect>(EEffectType::EditorBilboard),
                                                          pointLightBillboard, *this);
     mat->SetMaterialname("Point light editor billboard");
     m_editorIconsMaterials[EEditorIcon::PointLight] = mat;
 
     MaterialPaths areaLightBillboard{};
     areaLightBillboard.DiffuseMapPath = "Resources/EditorIcons/light-area.png";
-    mat = std::make_shared<ApplicationCore::PBRMaterial>(m_effectsLibrary.GetEffect(EEffectType::EditorBilboard),
+    mat = std::make_shared<ApplicationCore::PBRMaterial>(m_effectsLibrary.GetEffect<VulkanUtils::VRasterEffect>(EEffectType::EditorBilboard),
                                                          areaLightBillboard, *this);
     mat->SetMaterialname("Area light editor billboard");
     m_editorIconsMaterials[EEditorIcon::AreaLight] = mat;

--- a/Internal/Application/AssetsManger/AssetsManager.cpp
+++ b/Internal/Application/AssetsManger/AssetsManager.cpp
@@ -224,9 +224,17 @@ const std::vector<std::shared_ptr<ApplicationCore::SkyBoxMaterial>>& AssetsManag
     return m_skyBoxMaterials;
 }
 
-std::map<EEffectType, std::shared_ptr<VulkanUtils::VRasterEffect>> AssetsManager::GetEffects() const
+std::map<EEffectType, std::shared_ptr<VulkanUtils::VEffect>> AssetsManager::GetEffects() const
 {
     return m_effectsLibrary.effects;
+}
+std::map<EEffectType, std::shared_ptr<VulkanUtils::VRasterEffect>> AssetsManager::GetAllRasterEffects() const {
+    std::map<EEffectType, std::shared_ptr<VulkanUtils::VRasterEffect>> collectedEffects;
+    for (auto& effect :m_effectsLibrary.effects) {
+        if (auto e = std::dynamic_pointer_cast<VulkanUtils::VRasterEffect>(effect.second))
+        collectedEffects[effect.first] = e;
+    }
+    return collectedEffects;
 }
 
 void AssetsManager::AddModel(std::string path, std::vector<std::shared_ptr<ApplicationCore::SceneNode>>& model)

--- a/Internal/Application/AssetsManger/AssetsManager.hpp
+++ b/Internal/Application/AssetsManger/AssetsManager.hpp
@@ -35,7 +35,7 @@ class EffectsLibrary;
 }
 
 namespace VulkanUtils {
-class VEffect;
+class VRasterEffect;
 class VTransferOperationsManager;
 }  // namespace VulkanUtils
 
@@ -135,7 +135,7 @@ class AssetsManager
     // Effects
     //=========================
     EffectsLibrary&                                              GetEffectsLibrary() { return m_effectsLibrary; }
-    std::map<EEffectType, std::shared_ptr<VulkanUtils::VEffect>> GetEffects() const;
+    std::map<EEffectType, std::shared_ptr<VulkanUtils::VRasterEffect>> GetEffects() const;
 
     //=========================
     // Buffer Allocator

--- a/Internal/Application/AssetsManger/AssetsManager.hpp
+++ b/Internal/Application/AssetsManger/AssetsManager.hpp
@@ -19,6 +19,9 @@
 #include "Vulkan/VulkanCore/VImage/VImage.hpp"
 
 namespace VulkanUtils {
+class VEffect;
+}
+namespace VulkanUtils {
 class VEnvLightGenerator;
 }
 
@@ -135,7 +138,8 @@ class AssetsManager
     // Effects
     //=========================
     EffectsLibrary&                                              GetEffectsLibrary() { return m_effectsLibrary; }
-    std::map<EEffectType, std::shared_ptr<VulkanUtils::VRasterEffect>> GetEffects() const;
+    std::map<EEffectType, std::shared_ptr<VulkanUtils::VEffect>> GetEffects() const;
+    std::map<EEffectType, std::shared_ptr<VulkanUtils::VRasterEffect>> GetAllRasterEffects() const;
 
     //=========================
     // Buffer Allocator

--- a/Internal/Application/AssetsManger/EffectsLibrary/EffectsLibrary.cpp
+++ b/Internal/Application/AssetsManger/EffectsLibrary/EffectsLibrary.cpp
@@ -10,14 +10,14 @@
 #include "Vulkan/Renderer/Renderers/RenderingSystem.hpp"
 #include "Vulkan/Renderer/Renderers/SceneRenderer.hpp"
 #include "Vulkan/VulkanCore/Pipeline/VGraphicsPipeline.hpp"
-#include "Vulkan/Utils/VEffect/VEffect.hpp"
+#include "Vulkan/Utils/VEffect/VRasterEffect.hpp"
 #include "Vulkan/Utils/VResrouceGroup/VResourceGroupManager.hpp"
 #include "Vulkan/VulkanCore/Shader/VShader.hpp"
 
 namespace ApplicationCore {
 EffectsLibrary::EffectsLibrary(const VulkanCore::VDevice& device, VulkanUtils::VResourceGroupManager& pushDescriptorManager)
 {
-    auto frowardEffect = std::make_shared<VulkanUtils::VEffect>(
+    auto frowardEffect = std::make_shared<VulkanUtils::VRasterEffect>(
         device, "Forward lit", "Shaders/Compiled/BasicTriangle.vert.spv", "Shaders/Compiled/GGXColourFragmentMultiLight.frag.spv",
         pushDescriptorManager.GetPushDescriptor(VulkanUtils::EDescriptorLayoutStruct::ForwardShading));
 
@@ -32,7 +32,7 @@ EffectsLibrary::EffectsLibrary(const VulkanCore::VDevice& device, VulkanUtils::V
 
     //==============================================================================
 
-    auto transparentEffect = std::make_shared<VulkanUtils::VEffect>(
+    auto transparentEffect = std::make_shared<VulkanUtils::VRasterEffect>(
         device, "Forward lit transparent", "Shaders/Compiled/BasicTriangle.vert.spv",
         "Shaders/Compiled/GGXColourFragmentMultiLight.frag.spv",
         pushDescriptorManager.GetPushDescriptor(VulkanUtils::EDescriptorLayoutStruct::ForwardShading));
@@ -48,7 +48,7 @@ EffectsLibrary::EffectsLibrary(const VulkanCore::VDevice& device, VulkanUtils::V
 
     //==============================================================================
 
-    auto editorBillboards = std::make_shared<VulkanUtils::VEffect>(
+    auto editorBillboards = std::make_shared<VulkanUtils::VRasterEffect>(
         device, "Editor billboards", "Shaders/Compiled/EditorBillboard.vert.spv", "Shaders/Compiled/EditorBilboard.frag.spv",
         pushDescriptorManager.GetPushDescriptor(VulkanUtils::EDescriptorLayoutStruct::UnlitSingleTexture));
 
@@ -59,7 +59,7 @@ EffectsLibrary::EffectsLibrary(const VulkanCore::VDevice& device, VulkanUtils::V
 
     //==============================================================================
 
-    auto debugLine = std::make_shared<VulkanUtils::VEffect>(
+    auto debugLine = std::make_shared<VulkanUtils::VRasterEffect>(
         device, "Debug lines", "Shaders/Compiled/DebugLines.vert.spv", "Shaders/Compiled/DebugLines.frag.spv",
         pushDescriptorManager.GetPushDescriptor(VulkanUtils::EDescriptorLayoutStruct::Basic));
 
@@ -74,7 +74,7 @@ EffectsLibrary::EffectsLibrary(const VulkanCore::VDevice& device, VulkanUtils::V
 
     //==============================================================================
 
-    auto outline = std::make_shared<VulkanUtils::VEffect>(
+    auto outline = std::make_shared<VulkanUtils::VRasterEffect>(
         device, "Outline", "Shaders/Compiled/DebugLines.vert.spv", "Shaders/Compiled/Outliines.frag.spv",
         pushDescriptorManager.GetPushDescriptor(VulkanUtils::EDescriptorLayoutStruct::Basic));
 
@@ -88,7 +88,7 @@ EffectsLibrary::EffectsLibrary(const VulkanCore::VDevice& device, VulkanUtils::V
 
     //===============================================================================
 
-    auto debugShapes = std::make_shared<VulkanUtils::VEffect>(
+    auto debugShapes = std::make_shared<VulkanUtils::VRasterEffect>(
         device, "Debug shapes", "Shaders/Compiled/DebugLines.vert.spv", "Shaders/Compiled/DebugGeometry.frag.spv",
         pushDescriptorManager.GetPushDescriptor(VulkanUtils::EDescriptorLayoutStruct::Basic));
 
@@ -107,7 +107,7 @@ EffectsLibrary::EffectsLibrary(const VulkanCore::VDevice& device, VulkanUtils::V
 
     //===============================================================================
 
-    auto skybox = std::make_shared<VulkanUtils::VEffect>(
+    auto skybox = std::make_shared<VulkanUtils::VRasterEffect>(
         device, "Sky Box", "Shaders/Compiled/SkyBox.vert.spv", "Shaders/Compiled/SkyBox.frag.spv",
         pushDescriptorManager.GetPushDescriptor(VulkanUtils::EDescriptorLayoutStruct::UnlitSingleTexture));
 
@@ -120,7 +120,7 @@ EffectsLibrary::EffectsLibrary(const VulkanCore::VDevice& device, VulkanUtils::V
     BuildAllEffects();
 }
 
-std::shared_ptr<VulkanUtils::VEffect> EffectsLibrary::GetEffect(EEffectType type)
+std::shared_ptr<VulkanUtils::VRasterEffect> EffectsLibrary::GetEffect(EEffectType type)
 {
     assert(effects.contains(type));
     return effects[type];

--- a/Internal/Application/AssetsManger/EffectsLibrary/EffectsLibrary.cpp
+++ b/Internal/Application/AssetsManger/EffectsLibrary/EffectsLibrary.cpp
@@ -120,7 +120,7 @@ EffectsLibrary::EffectsLibrary(const VulkanCore::VDevice& device, VulkanUtils::V
     BuildAllEffects();
 }
 
-std::shared_ptr<VulkanUtils::VRasterEffect> EffectsLibrary::GetEffect(EEffectType type)
+std::shared_ptr<VulkanUtils::VEffect> EffectsLibrary::GetEffect(EEffectType type)
 {
     assert(effects.contains(type));
     return effects[type];

--- a/Internal/Application/AssetsManger/EffectsLibrary/EffectsLibrary.hpp
+++ b/Internal/Application/AssetsManger/EffectsLibrary/EffectsLibrary.hpp
@@ -7,6 +7,7 @@
 #include <map>
 #include <memory>
 #include <glm/fwd.hpp>
+#include "Vulkan/Utils/VEffect/VRasterEffect.hpp"
 
 
 namespace VulkanUtils {

--- a/Internal/Application/AssetsManger/EffectsLibrary/EffectsLibrary.hpp
+++ b/Internal/Application/AssetsManger/EffectsLibrary/EffectsLibrary.hpp
@@ -10,6 +10,9 @@
 
 
 namespace VulkanUtils {
+class VEffect;
+}
+namespace VulkanUtils {
 class VRasterEffect;
 class VResourceGroupManager;
 }  // namespace VulkanUtils
@@ -39,13 +42,22 @@ class EffectsLibrary
 {
   public:
     EffectsLibrary(const VulkanCore::VDevice& device, VulkanUtils::VResourceGroupManager& pushDescriptorManager);
-    std::map<EEffectType, std::shared_ptr<VulkanUtils::VRasterEffect>> effects;
+    std::map<EEffectType, std::shared_ptr<VulkanUtils::VEffect>> effects;
 
-    std::shared_ptr<VulkanUtils::VRasterEffect> GetEffect(EEffectType type);
+    std::shared_ptr<VulkanUtils::VEffect> GetEffect(EEffectType type);
+
+    template <typename T>
+    std::shared_ptr<T> GetEffect(EEffectType type);
 
     void BuildAllEffects();
     void Destroy();
 };
+template <typename T>
+std::shared_ptr<T> EffectsLibrary::GetEffect(EEffectType type)
+{
+  assert(effects.contains(type));
+  return std::dynamic_pointer_cast<T>(effects[type]);
+}
 
 }  // namespace ApplicationCore
 

--- a/Internal/Application/AssetsManger/EffectsLibrary/EffectsLibrary.hpp
+++ b/Internal/Application/AssetsManger/EffectsLibrary/EffectsLibrary.hpp
@@ -10,7 +10,7 @@
 
 
 namespace VulkanUtils {
-class VEffect;
+class VRasterEffect;
 class VResourceGroupManager;
 }  // namespace VulkanUtils
 
@@ -39,9 +39,9 @@ class EffectsLibrary
 {
   public:
     EffectsLibrary(const VulkanCore::VDevice& device, VulkanUtils::VResourceGroupManager& pushDescriptorManager);
-    std::map<EEffectType, std::shared_ptr<VulkanUtils::VEffect>> effects;
+    std::map<EEffectType, std::shared_ptr<VulkanUtils::VRasterEffect>> effects;
 
-    std::shared_ptr<VulkanUtils::VEffect> GetEffect(EEffectType type);
+    std::shared_ptr<VulkanUtils::VRasterEffect> GetEffect(EEffectType type);
 
     void BuildAllEffects();
     void Destroy();

--- a/Internal/Application/GLTFLoader/GltfLoader.cpp
+++ b/Internal/Application/GLTFLoader/GltfLoader.cpp
@@ -102,7 +102,7 @@ std::vector<std::shared_ptr<SceneNode>> GLTFLoader::LoadGLTFScene(std::filesyste
             {
                 MaterialPaths                paths    = {.saveToDisk = true};
                 std::shared_ptr<PBRMaterial> material = std::make_shared<ApplicationCore::PBRMaterial>(
-                    m_assetsManager.GetEffects()[EEffectType::ForwardShader], paths, m_assetsManager);
+                    m_assetsManager.GetAllRasterEffects()[EEffectType::ForwardShader], paths, m_assetsManager);
                 material->SetSavable(true);
                 material->GetMaterialDescription().values.diffuse.x = m.pbrData.baseColorFactor.x();
                 material->GetMaterialDescription().values.diffuse.y = m.pbrData.baseColorFactor.y();
@@ -178,11 +178,11 @@ std::vector<std::shared_ptr<SceneNode>> GLTFLoader::LoadGLTFScene(std::filesyste
 
                 if(m.alphaMode == fastgltf::AlphaMode::Blend)
                 {
-                    material->ChangeEffect(m_assetsManager.GetEffects()[EEffectType::AplhaBlend]);
+                    material->ChangeEffect(std::dynamic_pointer_cast<VulkanUtils::VRasterEffect>(m_assetsManager.GetEffects()[EEffectType::AplhaBlend]));
                 }
                 else if(m.alphaMode == fastgltf::AlphaMode::Mask)
                 {
-                    material->ChangeEffect(m_assetsManager.GetEffects()[EEffectType::AplhaBlend]);
+                    material->ChangeEffect(std::dynamic_pointer_cast<VulkanUtils::VRasterEffect>(m_assetsManager.GetEffects()[EEffectType::AplhaBlend]));
                 }
                 material->SetTransparent(m.alphaMode == fastgltf::AlphaMode::Blend);
                 materials.emplace_back(material);
@@ -194,7 +194,7 @@ std::vector<std::shared_ptr<SceneNode>> GLTFLoader::LoadGLTFScene(std::filesyste
 
             MaterialPaths                paths = {.saveToDisk = true};
             std::shared_ptr<PBRMaterial> material =
-                std::make_shared<ApplicationCore::PBRMaterial>(m_assetsManager.GetEffects()[EEffectType::ForwardShader],
+                std::make_shared<ApplicationCore::PBRMaterial>(m_assetsManager.GetAllRasterEffects()[EEffectType::ForwardShader],
                                                                paths, m_assetsManager);
             materials.emplace_back(material);
             m_assetsManager.m_materials.emplace_back(material);
@@ -223,7 +223,7 @@ std::vector<std::shared_ptr<SceneNode>> GLTFLoader::LoadGLTFScene(std::filesyste
             MaterialPaths paths;
 
             std::shared_ptr<PBRMaterial> mat =
-                std::make_shared<ApplicationCore::PBRMaterial>(m_assetsManager.GetEffects()[EEffectType::ForwardShader],
+                std::make_shared<ApplicationCore::PBRMaterial>(m_assetsManager.GetAllRasterEffects()[EEffectType::ForwardShader],
                                                                paths, m_assetsManager);
 
 

--- a/Internal/Application/Rendering/Material/BaseMaterial.cpp
+++ b/Internal/Application/Rendering/Material/BaseMaterial.cpp
@@ -6,19 +6,19 @@
 
 namespace ApplicationCore {
 
-BaseMaterial::BaseMaterial(std::shared_ptr<VulkanUtils::VEffect> effect)
+BaseMaterial::BaseMaterial(std::shared_ptr<VulkanUtils::VRasterEffect> effect)
     : m_initialEffect(effect)
     , m_materialEffect(effect)
 {
     ID = MaterialIndexCounter++;
 }
 
-void BaseMaterial::ChangeEffect(std::shared_ptr<VulkanUtils::VEffect> newEffect)
+void BaseMaterial::ChangeEffect(std::shared_ptr<VulkanUtils::VRasterEffect> newEffect)
 {
     m_materialEffect = newEffect;
 }
 
-std::shared_ptr<VulkanUtils::VEffect>& BaseMaterial::GetEffect()
+std::shared_ptr<VulkanUtils::VRasterEffect>& BaseMaterial::GetEffect()
 {
     return m_materialEffect;
 }

--- a/Internal/Application/Rendering/Material/BaseMaterial.hpp
+++ b/Internal/Application/Rendering/Material/BaseMaterial.hpp
@@ -10,7 +10,7 @@
 #include <vulkan/vulkan_handles.hpp>
 
 namespace VulkanUtils {
-class VEffect;
+class VRasterEffect;
 class VUniformBufferManager;
 };  // namespace VulkanUtils
 
@@ -24,16 +24,16 @@ inline int MaterialIndexCounter = 0;
 class BaseMaterial
 {
   public:
-    BaseMaterial(std::shared_ptr<VulkanUtils::VEffect> effect);
+    BaseMaterial(std::shared_ptr<VulkanUtils::VRasterEffect> effect);
 
     bool&                                  IsTransparent() { return m_transparent; }
     void                                   SetTransparent(bool value) { m_transparent = value; }
     bool                                   IsSavable() const { return m_savable; }
     void                                   SetSavable(bool savable) { m_savable = savable; }
     int                                    GetID() { return ID; }
-    virtual void                           ChangeEffect(std::shared_ptr<VulkanUtils::VEffect> newEffect);
+    virtual void                           ChangeEffect(std::shared_ptr<VulkanUtils::VRasterEffect> newEffect);
     std::string&                           GetMaterialName() { return m_materialName; }
-    std::shared_ptr<VulkanUtils::VEffect>& GetEffect();
+    std::shared_ptr<VulkanUtils::VRasterEffect>& GetEffect();
     void                                   ResetEffect();
     void                                   SetMaterialname(std::string newName);
     virtual void UpdateGPUTextureData(VulkanUtils::DescriptorSetTemplateVariantRef updateStruct) = 0;
@@ -43,8 +43,8 @@ class BaseMaterial
     bool                                  m_transparent = false;
     bool                                  m_savable     = false;
     int                                   ID;
-    std::shared_ptr<VulkanUtils::VEffect> m_materialEffect;
-    std::shared_ptr<VulkanUtils::VEffect> m_initialEffect;
+    std::shared_ptr<VulkanUtils::VRasterEffect> m_materialEffect;
+    std::shared_ptr<VulkanUtils::VRasterEffect> m_initialEffect;
     std::string                           m_materialName;
 
 

--- a/Internal/Application/Rendering/Material/PBRMaterial.cpp
+++ b/Internal/Application/Rendering/Material/PBRMaterial.cpp
@@ -11,13 +11,13 @@
 #include "Application/Structs/ApplicationStructs.hpp"
 #include "Application/Structs/ApplicationStructs.hpp"
 #include "Application/Utils/LinearyTransformedCosinesValues.hpp"
-#include "Vulkan/Utils/VEffect/VEffect.hpp"
+#include "Vulkan/Utils/VEffect/VRasterEffect.hpp"
 #include "Vulkan/Utils/VUniformBufferManager/VUniformBufferManager.hpp"
 #include "Vulkan/VulkanCore/Samplers/VSamplers.hpp"
 #include "Vulkan/VulkanCore/VImage/VImage2.hpp"
 
 namespace ApplicationCore {
-PBRMaterial::PBRMaterial(std::shared_ptr<VulkanUtils::VEffect> materialEffect, MaterialPaths& materialPaths, AssetsManager& assets_manager)
+PBRMaterial::PBRMaterial(std::shared_ptr<VulkanUtils::VRasterEffect> materialEffect, MaterialPaths& materialPaths, AssetsManager& assets_manager)
     : m_materialPaths(materialPaths)
     , BaseMaterial(materialEffect)
 {

--- a/Internal/Application/Rendering/Material/PBRMaterial.hpp
+++ b/Internal/Application/Rendering/Material/PBRMaterial.hpp
@@ -23,7 +23,7 @@ class VUniformBufferManager;
 }
 
 namespace VulkanUtils {
-class VEffect;
+class VRasterEffect;
 }
 
 namespace VulkanCore {
@@ -49,7 +49,7 @@ class PBRMaterial : public BaseMaterial
 {
   public:
     explicit PBRMaterial(MaterialPaths& materialPaths, AssetsManager& assets_manager);
-    explicit PBRMaterial(std::shared_ptr<VulkanUtils::VEffect> materialEffect, MaterialPaths& materialPaths, AssetsManager& assets_manager);
+    explicit PBRMaterial(std::shared_ptr<VulkanUtils::VRasterEffect> materialEffect, MaterialPaths& materialPaths, AssetsManager& assets_manager);
 
     PBRMaterialDescription&                          GetMaterialDescription() { return m_materialDescription; }
     std::shared_ptr<ApplicationCore::VTextureAsset>& GetTexture(ETextureType type) { return m_textures[type]; }

--- a/Internal/Application/Rendering/Material/SkyBoxMaterial.cpp
+++ b/Internal/Application/Rendering/Material/SkyBoxMaterial.cpp
@@ -15,7 +15,7 @@
 
 namespace ApplicationCore {
 SkyBoxMaterial::SkyBoxMaterial(const std::string& path, AssetsManager& assetsManager)
-    : BaseMaterial(assetsManager.GetEffectsLibrary().GetEffect(EEffectType::SkyBox))
+    : BaseMaterial(assetsManager.GetEffectsLibrary().GetEffect<VulkanUtils::VRasterEffect>(EEffectType::SkyBox))
 {
     assetsManager.GetHDRTexture(m_HDRTexture, path, true);
 }

--- a/Internal/Application/Rendering/Material/SkyBoxMaterial.cpp
+++ b/Internal/Application/Rendering/Material/SkyBoxMaterial.cpp
@@ -20,7 +20,7 @@ SkyBoxMaterial::SkyBoxMaterial(const std::string& path, AssetsManager& assetsMan
     assetsManager.GetHDRTexture(m_HDRTexture, path, true);
 }
 
-void SkyBoxMaterial::ChangeEffect(std::shared_ptr<VulkanUtils::VEffect> newEffect)
+void SkyBoxMaterial::ChangeEffect(std::shared_ptr<VulkanUtils::VRasterEffect> newEffect)
 {
     Utils::Logger::LogError("Can not change effect of SkyBox material");
 }

--- a/Internal/Application/Rendering/Material/SkyBoxMaterial.hpp
+++ b/Internal/Application/Rendering/Material/SkyBoxMaterial.hpp
@@ -22,7 +22,7 @@ class SkyBoxMaterial : public ApplicationCore::BaseMaterial
   public:
     SkyBoxMaterial(const std::string& path, AssetsManager& assetsManager);
 
-    void ChangeEffect(std::shared_ptr<VulkanUtils::VEffect> newEffect) override;
+    void ChangeEffect(std::shared_ptr<VulkanUtils::VRasterEffect> newEffect) override;
     std::shared_ptr<ApplicationCore::VTextureAsset> GetHDRTexture();
     void UpdateGPUTextureData(VulkanUtils::DescriptorSetTemplateVariantRef updateStruct) override;
 

--- a/Internal/Application/Rendering/Scene/AreaLightNode.cpp
+++ b/Internal/Application/Rendering/Scene/AreaLightNode.cpp
@@ -53,10 +53,10 @@ void AreaLightNode::Render(ApplicationCore::EffectsLibrary& effectsLibrary, Vulk
         data.material    = m_mesh->GetMaterial().get();
 
         if(renderingContext->WireFrameRendering)
-            data.effect = effectsLibrary.GetEffect(EEffectType::DebugLine);
+            data.effect = effectsLibrary.GetEffect<VulkanUtils::VRasterEffect>(EEffectType::DebugLine);
         else
         {
-            data.effect = effectsLibrary.GetEffect(EEffectType::EditorBilboard);
+            data.effect = effectsLibrary.GetEffect<VulkanUtils::VRasterEffect>(EEffectType::EditorBilboard);
         }
 
         data.position = m_transformation->GetPosition();
@@ -66,7 +66,7 @@ void AreaLightNode::Render(ApplicationCore::EffectsLibrary& effectsLibrary, Vulk
         renderingContext->AddDrawCall(data);
 
         // visualisation of the light
-        data.effect = effectsLibrary.GetEffect(EEffectType::DebugLine);
+        data.effect = effectsLibrary.GetEffect<VulkanUtils::VRasterEffect>(EEffectType::DebugLine);
         if(m_visualisationMesh)
         {
             data.vertexData = &m_visualisationMesh->GetMeshData()->vertexData;
@@ -77,7 +77,7 @@ void AreaLightNode::Render(ApplicationCore::EffectsLibrary& effectsLibrary, Vulk
 
         if(m_sceneNodeMetaData.IsSelected)
         {
-            data.effect = effectsLibrary.GetEffect(EEffectType::Outline);
+            data.effect = effectsLibrary.GetEffect<VulkanUtils::VRasterEffect>(EEffectType::Outline);
             renderingContext->AddDrawCall(data);
         }
     }

--- a/Internal/Application/Rendering/Scene/DirectionLightNode.cpp
+++ b/Internal/Application/Rendering/Scene/DirectionLightNode.cpp
@@ -52,9 +52,9 @@ void DirectionLightNode::Render(ApplicationCore::EffectsLibrary& effectsLibrary,
         data.modelMatrix = m_transformation->GetModelMatrix();
         data.material    = m_mesh->GetMaterial().get();
         if(renderingContext->WireFrameRendering)
-            data.effect = effectsLibrary.GetEffect(EEffectType::DebugLine);
+            data.effect = effectsLibrary.GetEffect<VulkanUtils::VRasterEffect>(EEffectType::DebugLine);
         else
-            data.effect = effectsLibrary.GetEffect(EEffectType::EditorBilboard);
+            data.effect = effectsLibrary.GetEffect<VulkanUtils::VRasterEffect>(EEffectType::EditorBilboard);
 
         data.position = m_transformation->GetPosition();
 
@@ -68,7 +68,7 @@ void DirectionLightNode::Render(ApplicationCore::EffectsLibrary& effectsLibrary,
         //=======================
         if(m_visualisationMesh)
         {
-            data.effect     = effectsLibrary.GetEffect(EEffectType::DebugLine);
+            data.effect     = effectsLibrary.GetEffect<VulkanUtils::VRasterEffect>(EEffectType::DebugLine);
             data.vertexData = &m_visualisationMesh->GetMeshData()->vertexData;
             data.indexData  = &m_visualisationMesh->GetMeshData()->indexData;
             data.indexCount = m_visualisationMesh->GetMeshIndexCount();

--- a/Internal/Application/Rendering/Scene/PointLightNode.cpp
+++ b/Internal/Application/Rendering/Scene/PointLightNode.cpp
@@ -59,10 +59,10 @@ void PointLightNode::Render(ApplicationCore::EffectsLibrary& effectsLibrary, Vul
         data.modelMatrix = m_transformation->GetModelMatrix();
         data.material    = m_mesh->GetMaterial().get();
         if(renderingContext->WireFrameRendering)
-            data.effect = effectsLibrary.GetEffect(EEffectType::DebugLine);
+            data.effect = effectsLibrary.GetEffect<VulkanUtils::VRasterEffect>(EEffectType::DebugLine);
         else
         {
-            data.effect = effectsLibrary.GetEffect(EEffectType::EditorBilboard);
+            data.effect = effectsLibrary.GetEffect<VulkanUtils::VRasterEffect>(EEffectType::EditorBilboard);
         }
 
         data.position = m_transformation->GetPosition();
@@ -73,7 +73,7 @@ void PointLightNode::Render(ApplicationCore::EffectsLibrary& effectsLibrary, Vul
 
         if(m_sceneNodeMetaData.IsSelected)
         {
-            data.effect = effectsLibrary.GetEffect(EEffectType::Outline);
+            data.effect = effectsLibrary.GetEffect<VulkanUtils::VRasterEffect>(EEffectType::Outline);
             renderingContext->AddDrawCall(data);
         }
     }

--- a/Internal/Application/Rendering/Scene/SceneNode.cpp
+++ b/Internal/Application/Rendering/Scene/SceneNode.cpp
@@ -233,12 +233,12 @@ void SceneNode::Render(ApplicationCore::EffectsLibrary& effectsLibrary, VulkanUt
         data.modelMatrix = m_transformation->GetModelMatrix();
         if(renderingContext->WireFrameRendering)
         {
-            data.effect = effectsLibrary.GetEffect(EEffectType::DebugLine);
+            data.effect = effectsLibrary.GetEffect<VulkanUtils::VRasterEffect>(EEffectType::DebugLine);
         }
         else if(m_mesh->m_currentMaterial->IsTransparent())
         {
             data.inDepthPrePass = false;
-            data.effect         = effectsLibrary.GetEffect(EEffectType::AplhaBlend);
+            data.effect         = effectsLibrary.GetEffect<VulkanUtils::VRasterEffect>(EEffectType::AplhaBlend);
         }
         else
         {
@@ -258,7 +258,7 @@ void SceneNode::Render(ApplicationCore::EffectsLibrary& effectsLibrary, VulkanUt
         {
             data.inDepthPrePass = false;
 
-            data.effect = effectsLibrary.GetEffect(EEffectType::Outline);
+            data.effect = effectsLibrary.GetEffect<VulkanUtils::VRasterEffect>(EEffectType::Outline);
             data.modelMatrix *= glm::scale(glm::mat4(1.0f), glm::vec3(1.0f + GlobalVariables::RenderingOptions::OutlineWidth));
             renderingContext->AddDrawCall(data);
         }

--- a/Internal/Application/Rendering/Scene/SceneNode.cpp
+++ b/Internal/Application/Rendering/Scene/SceneNode.cpp
@@ -272,7 +272,7 @@ void SceneNode::Render(ApplicationCore::EffectsLibrary& effectsLibrary, VulkanUt
             data.indexData  = &m_mesh->GetMeshData()->indexData_BB;
             data.indexCount = m_mesh->GetMeshData()->indexData_BB.size / sizeof(uint32_t);
             ;
-            data.effect = effectsLibrary.GetEffect(EEffectType::DebugLine);
+            data.effect = effectsLibrary.GetEffect<VulkanUtils::VRasterEffect>(EEffectType::DebugLine);
             renderingContext->AddDrawCall(data);
         }
 

--- a/Internal/Application/Rendering/Scene/SkyBoxNode.cpp
+++ b/Internal/Application/Rendering/Scene/SkyBoxNode.cpp
@@ -43,7 +43,7 @@ void SkyBoxNode::Render(ApplicationCore::EffectsLibrary& effectsLibrary, VulkanU
     data.vertexData = &m_mesh->GetMeshData()->vertexData;
     data.indexData  = &m_mesh->GetMeshData()->indexData;
 
-    data.effect         = effectsLibrary.GetEffect(EEffectType::SkyBox);
+    data.effect         = effectsLibrary.GetEffect<VulkanUtils::VRasterEffect>(EEffectType::SkyBox);
     data.inDepthPrePass = false;
     data.position       = m_transformation->GetPosition();
     data.bounds         = &m_mesh->GetMeshData()->bounds;

--- a/Internal/Editor/Views/ContentBrowser/ContentBrowser.cpp
+++ b/Internal/Editor/Views/ContentBrowser/ContentBrowser.cpp
@@ -13,7 +13,7 @@
 #include "Application/Rendering/Mesh/StaticMesh.hpp"
 #include "Application/Rendering/Scene/Scene.hpp"
 #include "Application/Rendering/Scene/SceneNode.hpp"
-#include "Vulkan/Utils/VEffect/VEffect.hpp"
+#include "Vulkan/Utils/VEffect/VRasterEffect.hpp"
 
 ContentBrowser::ContentBrowser(ApplicationCore::AssetsManager& assetManager, ApplicationCore::Scene& scene)
     : IUserInterfaceElement()

--- a/Internal/Editor/Views/DetailsPanel/DetailsPanel.cpp
+++ b/Internal/Editor/Views/DetailsPanel/DetailsPanel.cpp
@@ -17,7 +17,7 @@
 #include "Application/Rendering/Scene/PointLightNode.hpp"
 #include "Application/Rendering/Scene/SceneNode.hpp"
 #include "Application/Rendering/Scene/SkyBoxNode.hpp"
-#include "Vulkan/Utils/VEffect/VEffect.hpp"
+#include "Vulkan/Utils/VEffect/VRasterEffect.hpp"
 
 namespace VEditor {
 DetailsPanel::DetailsPanel(const ApplicationCore::AssetsManager& assetsManager)

--- a/Internal/Editor/Views/DetailsPanel/DetailsPanel.cpp
+++ b/Internal/Editor/Views/DetailsPanel/DetailsPanel.cpp
@@ -160,7 +160,7 @@ void DetailsPanel::RenderMaterialEditorPanel()
                 auto label = ICON_FA_WAND_MAGIC_SPARKLES " " + effect.second->GetName();
                 if(ImGui::Selectable(label.c_str(), effect.second == m_selectedSceneNode->GetMesh()->GetMaterial()->GetEffect()))
                 {
-                    m_selectedSceneNode->GetMesh()->GetMaterial()->ChangeEffect(effect.second);
+                    m_selectedSceneNode->GetMesh()->GetMaterial()->ChangeEffect(std::dynamic_pointer_cast<VulkanUtils::VRasterEffect>(effect.second));
                 }
             }
             ImGui::EndCombo();

--- a/Internal/Editor/Views/RenderingOptions/RenderingOptions.cpp
+++ b/Internal/Editor/Views/RenderingOptions/RenderingOptions.cpp
@@ -11,7 +11,7 @@
 #include "Application/Rendering/Scene/Scene.hpp"
 #include "Vulkan/Renderer/Renderers/RenderingSystem.hpp"
 #include "Vulkan/Renderer/Renderers/SceneRenderer.hpp"
-#include "Vulkan/Utils/VEffect/VEffect.hpp"
+#include "Vulkan/Utils/VEffect/VRasterEffect.hpp"
 #include "Vulkan/Utils/VRayTracingManager/VRayTracingDataManager.hpp"
 
 namespace VEditor {

--- a/Internal/Vulkan/Global/VulkanStructs.hpp
+++ b/Internal/Vulkan/Global/VulkanStructs.hpp
@@ -20,7 +20,7 @@ class BaseMaterial;
 }
 
 namespace VulkanUtils {
-class VEffect;
+class VRasterEffect;
 }
 
 namespace ApplicationCore {
@@ -185,7 +185,7 @@ struct DrawCallData
     bool selected       = false;
 
     ApplicationCore::BaseMaterial*        material;
-    std::shared_ptr<VulkanUtils::VEffect> effect;
+    std::shared_ptr<VulkanUtils::VRasterEffect> effect;
 
     friend bool operator==(const DrawCallData& lhs, const ObjectDataUniform& rhs)
     {

--- a/Internal/Vulkan/Renderer/Renderers/RenderingSystem.cpp
+++ b/Internal/Vulkan/Renderer/Renderers/RenderingSystem.cpp
@@ -19,7 +19,7 @@
 #include "Vulkan/Renderer/Renderers/UserInterfaceRenderer.hpp"
 #include "Vulkan/Renderer/Renderers/SceneRenderer.hpp"
 #include "Vulkan/Utils/TransferOperationsManager/VTransferOperationsManager.hpp"
-#include "Vulkan/Utils/VEffect/VEffect.hpp"
+#include "Vulkan/Utils/VEffect/VRasterEffect.hpp"
 #include "Vulkan/Utils/VEnvLightGenerator/VEnvLightGenerator.hpp"
 #include "Vulkan/Utils/VRayTracingManager/VRayTracingDataManager.hpp"
 #include "Vulkan/Utils/VUniformBufferManager/VUniformBufferManager.hpp"

--- a/Internal/Vulkan/Renderer/Renderers/SceneRenderer.cpp
+++ b/Internal/Vulkan/Renderer/Renderers/SceneRenderer.cpp
@@ -19,7 +19,7 @@
 #include "Vulkan/Global/RenderingOptions.hpp"
 #include "Vulkan/Utils/VPipelineBarriers.hpp"
 #include "Vulkan/Utils/TransferOperationsManager/VTransferOperationsManager.hpp"
-#include "Vulkan/Utils/VEffect/VEffect.hpp"
+#include "Vulkan/Utils/VEffect/VRasterEffect.hpp"
 #include "Vulkan/Utils/VUniformBufferManager/VUniformBufferManager.hpp"
 #include "Vulkan/VulkanCore/CommandBuffer/VCommandPool.hpp"
 #include "Vulkan/VulkanCore/Samplers/VSamplers.hpp"
@@ -51,7 +51,7 @@ SceneRenderer::SceneRenderer(const VulkanCore::VDevice& device, VulkanUtils::VRe
     //=========================
     // CONFIGURE DEAPTH PASS EFFECT
     //=========================
-    m_depthPrePassEffect = std::make_unique<VulkanUtils::VEffect>(
+    m_depthPrePassEffect = std::make_unique<VulkanUtils::VRasterEffect>(
         m_device, "Depth-PrePass effect", "Shaders/Compiled/DepthPrePass.vert.spv", "Shaders/Compiled/DepthPrePass.frag.spv",
         m_pushDescriptorManager.GetPushDescriptor(VulkanUtils::EDescriptorLayoutStruct::Basic));
     m_depthPrePassEffect->SetVertexInputMode(EVertexInput::PositionOnly).SetDepthOpLess();

--- a/Internal/Vulkan/Renderer/Renderers/SceneRenderer.hpp
+++ b/Internal/Vulkan/Renderer/Renderers/SceneRenderer.hpp
@@ -52,7 +52,7 @@ class SceneRenderer : public Renderer::BaseRenderer
   private:
     const VulkanCore::VDevice& m_device;
 
-    std::unique_ptr<VulkanUtils::VEffect> m_depthPrePassEffect;
+    std::unique_ptr<VulkanUtils::VRasterEffect> m_depthPrePassEffect;
 
     VulkanUtils::VResourceGroupManager& m_pushDescriptorManager;
 

--- a/Internal/Vulkan/Utils/VEffect/VEffect.cpp
+++ b/Internal/Vulkan/Utils/VEffect/VEffect.cpp
@@ -25,5 +25,5 @@ DescriptorSetTemplateVariant& VEffect::GetResrouceGroupStructVariant()
 vk::DescriptorUpdateTemplate& VEffect::GetUpdateTemplate() { return m_resourceGroup->GetUpdateTemplate(); }
 unsigned short                VEffect::EvaluateRenderingOrder() { return 0; }
 int&                          VEffect::GetID() {return m_ID;}
-EDescriptorLayoutStruct       VEffect::GetLayoutStructType() {}
+EDescriptorLayoutStruct       VEffect::GetLayoutStructType() { return m_resourceGroup->GetResourceGroupStrucutureType(); }
 }  // namespace VulkanUtils

--- a/Internal/Vulkan/Utils/VEffect/VEffect.cpp
+++ b/Internal/Vulkan/Utils/VEffect/VEffect.cpp
@@ -1,0 +1,29 @@
+//
+// Created by wpsimon09 on 23/04/25.
+//
+
+#include "VEffect.hpp"
+
+#include "Vulkan/Utils/VResrouceGroup/VResrouceGroup.hpp"
+
+namespace VulkanUtils {
+VEffect::VEffect(const VulkanCore::VDevice& device, const std::string& name, std::shared_ptr<VulkanUtils::VShaderResrouceGroup>& descriptorSet)
+    : m_device(device)
+    , m_name(name)
+    , m_resourceGroup(descriptorSet)
+{
+    m_ID = EffectIndexCounter++;
+}
+std::string& VEffect::GetName()
+{
+    return m_name;
+}
+DescriptorSetTemplateVariant& VEffect::GetResrouceGroupStructVariant()
+{
+    return m_resourceGroup->GetResourceGroupStruct();
+}
+vk::DescriptorUpdateTemplate& VEffect::GetUpdateTemplate() { return m_resourceGroup->GetUpdateTemplate(); }
+unsigned short                VEffect::EvaluateRenderingOrder() { return 0; }
+int&                          VEffect::GetID() {return m_ID;}
+EDescriptorLayoutStruct       VEffect::GetLayoutStructType() {}
+}  // namespace VulkanUtils

--- a/Internal/Vulkan/Utils/VEffect/VEffect.hpp
+++ b/Internal/Vulkan/Utils/VEffect/VEffect.hpp
@@ -31,7 +31,7 @@ class VEffect
     int&                          GetID();
     EDescriptorLayoutStruct       GetLayoutStructType();
 
-  private:
+  protected:
     const VulkanCore::VDevice&                         m_device;
     std::string                                        m_name;
     std::shared_ptr<VulkanUtils::VShaderResrouceGroup> m_resourceGroup;

--- a/Internal/Vulkan/Utils/VEffect/VEffect.hpp
+++ b/Internal/Vulkan/Utils/VEffect/VEffect.hpp
@@ -1,0 +1,43 @@
+//
+// Created by wpsimon09 on 23/04/25.
+//
+
+#ifndef VEFFECT_HPP
+#define VEFFECT_HPP
+#include "Vulkan/VulkanCore/Device/VDevice.hpp"
+
+inline int EffectIndexCounter = 0;
+
+namespace VulkanUtils {
+class VShaderResrouceGroup;
+
+
+class VEffect
+{
+  public:
+    explicit VEffect(const VulkanCore::VDevice&                          device,
+                     const std::string&                                  name,
+                     std::shared_ptr<VulkanUtils::VShaderResrouceGroup>& descriptorSet);
+
+  public:
+    std::string&                  GetName();
+    DescriptorSetTemplateVariant& GetResrouceGroupStructVariant();
+    virtual void                  BuildEffect()                                    = 0;
+    virtual vk::PipelineLayout    GetPipelineLayout()                              = 0;
+    virtual void                  BindPipeline(const vk::CommandBuffer& cmdBuffer) = 0;
+    virtual void                  Destroy()                                        = 0;
+    vk::DescriptorUpdateTemplate& GetUpdateTemplate();
+    unsigned short                EvaluateRenderingOrder();
+    int&                          GetID();
+    EDescriptorLayoutStruct       GetLayoutStructType();
+
+  private:
+    const VulkanCore::VDevice&                         m_device;
+    std::string                                        m_name;
+    std::shared_ptr<VulkanUtils::VShaderResrouceGroup> m_resourceGroup;
+    int                                                m_ID;
+};
+
+}  // namespace VulkanUtils
+
+#endif  //VEFFECT_HPP

--- a/Internal/Vulkan/Utils/VEffect/VRasterEffect.cpp
+++ b/Internal/Vulkan/Utils/VEffect/VRasterEffect.cpp
@@ -12,16 +12,13 @@ VRasterEffect::VRasterEffect(const VulkanCore::VDevice&                         
                  const std::string&                                  name,
                  const VulkanCore::VShader&                          shader,
                  std::shared_ptr<VulkanUtils::VShaderResrouceGroup>& shaderResourceGroup)
-    : m_device(device)
-    , m_resourceGroup(shaderResourceGroup)
-    , m_name(name)
+    : VEffect(device, name, shaderResourceGroup)
 {
     m_pipeline = std::make_unique<VulkanCore::VGraphicsPipeline>(device, shader, m_resourceGroup->GetDescriptorSetLayout());
     m_pipeline->Init();
 
     m_resourceGroup->CreateDstUpdateInfo(*m_pipeline);
 
-    m_ID = EffectIndexCounter++;
 }
 
 VRasterEffect::VRasterEffect(const VulkanCore::VDevice&                          device,
@@ -29,9 +26,7 @@ VRasterEffect::VRasterEffect(const VulkanCore::VDevice&                         
                  const std::string&                                  vertex,
                  const std::string&                                  fragment,
                  std::shared_ptr<VulkanUtils::VShaderResrouceGroup>& descriptorSet)
-    : m_device(device)
-    , m_resourceGroup(descriptorSet)
-    , m_name(name)
+    : VEffect(device, name, descriptorSet)
     , m_shader(std::in_place, device, vertex, fragment)
 {
     m_pipeline =
@@ -40,7 +35,6 @@ VRasterEffect::VRasterEffect(const VulkanCore::VDevice&                         
 
     m_resourceGroup->CreateDstUpdateInfo(*m_pipeline);
 
-    m_ID = EffectIndexCounter++;
 }
 
 VRasterEffect& VRasterEffect::SetDisableDepthTest()
@@ -194,15 +188,6 @@ VRasterEffect& VRasterEffect::SetDepthOpAllways()
 }
 
 
-std::string& VRasterEffect::GetName()
-{
-    return m_name;
-}
-
-DescriptorSetTemplateVariant& VRasterEffect::GetResrouceGroupStructVariant()
-{
-    return m_resourceGroup->GetResourceGroupStruct();
-}
 
 void VRasterEffect::BuildEffect()
 {
@@ -231,23 +216,4 @@ void VRasterEffect::Destroy()
     m_pipeline->Destroy();
 }
 
-vk::DescriptorUpdateTemplate& VRasterEffect::GetUpdateTemplate()
-{
-    return m_resourceGroup->GetUpdateTemplate();
-}
-
-unsigned short VRasterEffect::EvaluateRenderingOrder()
-{
-    return 0;
-}
-
-int& VRasterEffect::GetID()
-{
-    return m_ID;
-}
-
-EDescriptorLayoutStruct VRasterEffect::GetLayoutStructType()
-{
-    return m_resourceGroup->GetResourceGroupStrucutureType();
-}
 }  // namespace VulkanUtils

--- a/Internal/Vulkan/Utils/VEffect/VRasterEffect.cpp
+++ b/Internal/Vulkan/Utils/VEffect/VRasterEffect.cpp
@@ -2,13 +2,13 @@
 // Created by wpsimon09 on 19/03/25.
 //
 
-#include "VEffect.hpp"
+#include "VRasterEffect.hpp"
 #include "Vulkan/VulkanCore/Shader/VShader.hpp"
 #include "Vulkan/Renderer/RenderTarget/RenderTarget.hpp"
 #include "Vulkan/VulkanCore/Pipeline/VGraphicsPipeline.hpp"
 
 namespace VulkanUtils {
-VEffect::VEffect(const VulkanCore::VDevice&                          device,
+VRasterEffect::VRasterEffect(const VulkanCore::VDevice&                          device,
                  const std::string&                                  name,
                  const VulkanCore::VShader&                          shader,
                  std::shared_ptr<VulkanUtils::VShaderResrouceGroup>& shaderResourceGroup)
@@ -24,7 +24,7 @@ VEffect::VEffect(const VulkanCore::VDevice&                          device,
     m_ID = EffectIndexCounter++;
 }
 
-VEffect::VEffect(const VulkanCore::VDevice&                          device,
+VRasterEffect::VEffect(const VulkanCore::VDevice&                          device,
                  const std::string&                                  name,
                  const std::string&                                  vertex,
                  const std::string&                                  fragment,
@@ -43,92 +43,92 @@ VEffect::VEffect(const VulkanCore::VDevice&                          device,
     m_ID = EffectIndexCounter++;
 }
 
-VEffect& VEffect::SetDisableDepthTest()
+VRasterEffect& VRasterEffect::SetDisableDepthTest()
 {
     m_pipeline->m_depthStencil.depthTestEnable = false;
     return *this;
 }
 
-VEffect& VEffect::SetLineWidth(int lineWidth)
+VRasterEffect& VRasterEffect::SetLineWidth(int lineWidth)
 {
     m_pipeline->m_rasterizer.lineWidth = lineWidth;
     return *this;
 }
 
-VEffect& VEffect::SetCullFrontFace()
+VRasterEffect& VRasterEffect::SetCullFrontFace()
 {
     m_pipeline->m_rasterizer.cullMode = vk::CullModeFlagBits::eFront;
     return *this;
 }
 
-VEffect& VEffect::SetCullNone()
+VRasterEffect& VRasterEffect::SetCullNone()
 {
     m_pipeline->SetCullMode(vk::CullModeFlagBits::eNone);
     return *this;
 }
 
-VEffect& VEffect::SetDisableDepthWrite()
+VRasterEffect& VRasterEffect::SetDisableDepthWrite()
 {
     m_pipeline->m_depthStencil.depthWriteEnable = false;
     return *this;
 }
 
-VEffect& VEffect::SetTopology(vk::PrimitiveTopology topology)
+VRasterEffect& VRasterEffect::SetTopology(vk::PrimitiveTopology topology)
 {
     m_pipeline->m_inputAssembly.topology = topology;
     return *this;
 }
 
-VEffect& VEffect::SetPolygonLine()
+VRasterEffect& VRasterEffect::SetPolygonLine()
 {
     m_pipeline->m_rasterizer.polygonMode = vk::PolygonMode::eLine;
     return *this;
 }
 
-VEffect& VEffect::SetPolygonPoint()
+VRasterEffect& VRasterEffect::SetPolygonPoint()
 {
     m_pipeline->m_rasterizer.polygonMode = vk::PolygonMode::ePoint;
     return *this;
 }
 
-VEffect& VEffect::EnableAdditiveBlending()
+VRasterEffect& VRasterEffect::EnableAdditiveBlending()
 {
     m_pipeline->EnableBlendingAdditive();
     return *this;
 }
 
-VEffect& VEffect::OutputHDR()
+VRasterEffect& VRasterEffect::OutputHDR()
 {
     std::vector<vk::Format> formats = {vk::Format::eR16G16B16A16Sfloat};
     m_pipeline->m_outputFormats     = formats;
     return *this;
 }
 
-VEffect& VEffect::SetDepthOpEqual()
+VRasterEffect& VRasterEffect::SetDepthOpEqual()
 {
     m_pipeline->m_depthStencil.depthCompareOp = vk::CompareOp::eEqual;
     return *this;
 }
 
-VEffect& VEffect::SetDepthOpLessEqual()
+VRasterEffect& VRasterEffect::SetDepthOpLessEqual()
 {
     m_pipeline->m_depthStencil.depthCompareOp = vk::CompareOp::eLessOrEqual;
     return *this;
 }
 
-VEffect& VEffect::SetFrontFaceClockWise()
+VRasterEffect& VRasterEffect::SetFrontFaceClockWise()
 {
     m_pipeline->m_rasterizer.frontFace = vk::FrontFace::eClockwise;
     return *this;
 }
 
-VEffect& VEffect::SetVertexInputMode(EVertexInput inputMode)
+VRasterEffect& VRasterEffect::SetVertexInputMode(EVertexInput inputMode)
 {
     m_pipeline->CreateVertexInputBindingAndAttributes(inputMode);
     return *this;
 }
 
-VEffect& VEffect::SetStencilTestOutline()
+VRasterEffect& VRasterEffect::SetStencilTestOutline()
 {
     m_pipeline->m_depthStencil.back.compareOp   = vk::CompareOp::eNotEqual;
     m_pipeline->m_depthStencil.back.failOp      = vk::StencilOp::eKeep;
@@ -142,31 +142,31 @@ VEffect& VEffect::SetStencilTestOutline()
     return *this;
 }
 
-VEffect& VEffect::DisableStencil()
+VRasterEffect& VRasterEffect::DisableStencil()
 {
     m_pipeline->m_depthStencil.stencilTestEnable = vk::False;
     return *this;
 }
 
-VEffect& VEffect::SetDepthTestNever()
+VRasterEffect& VRasterEffect::SetDepthTestNever()
 {
     m_pipeline->m_depthStencil.depthCompareOp = vk::CompareOp::eNever;
     return *this;
 }
 
-VEffect& VEffect::SetColourOutputFormat(vk::Format format)
+VRasterEffect& VRasterEffect::SetColourOutputFormat(vk::Format format)
 {
     m_pipeline->SetColourOutputFormat(format);
     return *this;
 }
 
-VEffect& VEffect::SetPiplineNoMultiSampling()
+VRasterEffect& VRasterEffect::SetPiplineNoMultiSampling()
 {
     m_pipeline->m_multisampling.rasterizationSamples = vk::SampleCountFlagBits::e1;
     return *this;
 }
 
-VEffect& VEffect::SetNullVertexBinding()
+VRasterEffect& VRasterEffect::SetNullVertexBinding()
 {
     m_pipeline->m_vertexInputState.vertexAttributeDescriptionCount = 0;
     m_pipeline->m_vertexInputState.vertexBindingDescriptionCount   = 0;
@@ -175,36 +175,36 @@ VEffect& VEffect::SetNullVertexBinding()
     return *this;
 }
 
-VEffect& VEffect::DissableFragmentWrite()
+VRasterEffect& VRasterEffect::DissableFragmentWrite()
 {
     m_pipeline->m_rasterizer.rasterizerDiscardEnable = vk::True;
     return *this;
 }
 
-VEffect& VEffect::SetDepthOpLess()
+VRasterEffect& VRasterEffect::SetDepthOpLess()
 {
     m_pipeline->m_depthStencil.depthCompareOp = vk::CompareOp::eLess;
     return *this;
 }
 
-VEffect& VEffect::SetDepthOpAllways()
+VRasterEffect& VRasterEffect::SetDepthOpAllways()
 {
     m_pipeline->m_depthStencil.depthCompareOp = vk::CompareOp::eAlways;
     return *this;
 }
 
 
-std::string& VEffect::GetName()
+std::string& VRasterEffect::GetName()
 {
     return m_name;
 }
 
-DescriptorSetTemplateVariant& VEffect::GetResrouceGroupStructVariant()
+DescriptorSetTemplateVariant& VRasterEffect::GetResrouceGroupStructVariant()
 {
     return m_resourceGroup->GetResourceGroupStruct();
 }
 
-void VEffect::BuildEffect()
+void VRasterEffect::BuildEffect()
 {
 
     auto pipelines = m_device.GetDevice().createGraphicsPipelines(nullptr, m_pipeline->GetGraphicsPipelineCreateInfoStruct());
@@ -216,37 +216,37 @@ void VEffect::BuildEffect()
     m_shader->DestroyExistingShaderModules();
 }
 
-vk::PipelineLayout VEffect::GetPipelineLayout()
+vk::PipelineLayout VRasterEffect::GetPipelineLayout()
 {
     return m_pipeline->GetPipelineLayout();
 }
 
-void VEffect::BindPipeline(const vk::CommandBuffer& cmdBuffer)
+void VRasterEffect::BindPipeline(const vk::CommandBuffer& cmdBuffer)
 {
     cmdBuffer.bindPipeline(vk::PipelineBindPoint::eGraphics, m_pipeline->GetPipelineInstance());
 }
 
-void VEffect::Destroy()
+void VRasterEffect::Destroy()
 {
     m_pipeline->Destroy();
 }
 
-vk::DescriptorUpdateTemplate& VEffect::GetUpdateTemplate()
+vk::DescriptorUpdateTemplate& VRasterEffect::GetUpdateTemplate()
 {
     return m_resourceGroup->GetUpdateTemplate();
 }
 
-unsigned short VEffect::EvaluateRenderingOrder()
+unsigned short VRasterEffect::EvaluateRenderingOrder()
 {
     return 0;
 }
 
-int& VEffect::GetID()
+int& VRasterEffect::GetID()
 {
     return m_ID;
 }
 
-EDescriptorLayoutStruct VEffect::GetLayoutStructType()
+EDescriptorLayoutStruct VRasterEffect::GetLayoutStructType()
 {
     return m_resourceGroup->GetResourceGroupStrucutureType();
 }

--- a/Internal/Vulkan/Utils/VEffect/VRasterEffect.cpp
+++ b/Internal/Vulkan/Utils/VEffect/VRasterEffect.cpp
@@ -24,7 +24,7 @@ VRasterEffect::VRasterEffect(const VulkanCore::VDevice&                         
     m_ID = EffectIndexCounter++;
 }
 
-VRasterEffect::VEffect(const VulkanCore::VDevice&                          device,
+VRasterEffect::VRasterEffect(const VulkanCore::VDevice&                          device,
                  const std::string&                                  name,
                  const std::string&                                  vertex,
                  const std::string&                                  fragment,

--- a/Internal/Vulkan/Utils/VEffect/VRasterEffect.hpp
+++ b/Internal/Vulkan/Utils/VEffect/VRasterEffect.hpp
@@ -9,6 +9,9 @@
 #include "Vulkan/Utils/VResrouceGroup/VResourceGroupManager.hpp"
 #include "Vulkan/VulkanCore/Shader/VShader.hpp"
 
+namespace VulkanCore::RTX {
+struct RTXShaderPaths;
+}
 namespace Renderer {
 class RenderTarget;
 }
@@ -22,46 +25,50 @@ inline int EffectIndexCounter = 0;
 
 namespace VulkanUtils {
 
-class VEffect
+class VRasterEffect
 {
   public:
-    VEffect(const VulkanCore::VDevice&                          device,
+    VRasterEffect(const VulkanCore::VDevice&                          device,
             const std::string&                                  name,
             const VulkanCore::VShader&                          shader,
             std::shared_ptr<VulkanUtils::VShaderResrouceGroup>& shaderResourceGroup);
 
-    VEffect(const VulkanCore::VDevice&                          device,
+    VRasterEffect(const VulkanCore::VDevice&                          device,
             const std::string&                                  name,
             const std::string&                                  vertex,
             const std::string&                                  fragment,
             std::shared_ptr<VulkanUtils::VShaderResrouceGroup>& descriptorSet);
 
-    //=======================================
-    // Effect building
-    //=======================================
-    VEffect& SetDisableDepthTest();
-    VEffect& SetLineWidth(int lineWidth);
-    VEffect& SetCullFrontFace();
-    VEffect& SetCullNone();
-    VEffect& SetDisableDepthWrite();
-    VEffect& SetTopology(vk::PrimitiveTopology topology);
-    VEffect& SetPolygonLine();
-    VEffect& SetPolygonPoint();
-    VEffect& EnableAdditiveBlending();
-    VEffect& OutputHDR();
-    VEffect& SetDepthOpEqual();
-    VEffect& SetDepthOpLessEqual();
-    VEffect& SetFrontFaceClockWise();
-    VEffect& SetVertexInputMode(EVertexInput inputMode);
-    VEffect& SetStencilTestOutline();
-    VEffect& DisableStencil();
-    VEffect& SetDepthTestNever();
-    VEffect& SetColourOutputFormat(vk::Format format);
-    VEffect& SetPiplineNoMultiSampling();
-    VEffect& SetNullVertexBinding();
-    VEffect& DissableFragmentWrite();
-    VEffect& SetDepthOpLess();
-    VEffect& SetDepthOpAllways();
+    VRasterEffect(const VulkanCore::VDevice&                          device,
+            const VulkanCore::RTX::RTXShaderPaths&              rtShaderPaths,
+            std::shared_ptr<VulkanUtils::VShaderResrouceGroup>& resourceGroup);
+
+        //=======================================
+        // Effect building
+        //=======================================
+    VRasterEffect& SetDisableDepthTest();
+    VRasterEffect& SetLineWidth(int lineWidth);
+    VRasterEffect& SetCullFrontFace();
+    VRasterEffect& SetCullNone();
+    VRasterEffect& SetDisableDepthWrite();
+    VRasterEffect& SetTopology(vk::PrimitiveTopology topology);
+    VRasterEffect& SetPolygonLine();
+    VRasterEffect& SetPolygonPoint();
+    VRasterEffect& EnableAdditiveBlending();
+    VRasterEffect& OutputHDR();
+    VRasterEffect& SetDepthOpEqual();
+    VRasterEffect& SetDepthOpLessEqual();
+    VRasterEffect& SetFrontFaceClockWise();
+    VRasterEffect& SetVertexInputMode(EVertexInput inputMode);
+    VRasterEffect& SetStencilTestOutline();
+    VRasterEffect& DisableStencil();
+    VRasterEffect& SetDepthTestNever();
+    VRasterEffect& SetColourOutputFormat(vk::Format format);
+    VRasterEffect& SetPiplineNoMultiSampling();
+    VRasterEffect& SetNullVertexBinding();
+    VRasterEffect& DissableFragmentWrite();
+    VRasterEffect& SetDepthOpLess();
+    VRasterEffect& SetDepthOpAllways();
 
 
     //=======================================
@@ -86,9 +93,9 @@ class VEffect
     int                                                m_ID;
 
   private:
-    friend bool operator==(const VEffect& lhs, const VEffect& rhs) { return lhs.m_ID == rhs.m_ID; }
+    friend bool operator==(const VRasterEffect& lhs, const VRasterEffect& rhs) { return lhs.m_ID == rhs.m_ID; }
 
-    friend bool operator!=(const VEffect& lhs, const VEffect& rhs) { return !(lhs == rhs); }
+    friend bool operator!=(const VRasterEffect& lhs, const VRasterEffect& rhs) { return !(lhs == rhs); }
 };
 }  // namespace VulkanUtils
 

--- a/Internal/Vulkan/Utils/VEffect/VRasterEffect.hpp
+++ b/Internal/Vulkan/Utils/VEffect/VRasterEffect.hpp
@@ -2,8 +2,11 @@
 // Created by wpsimon09 on 19/03/25.
 //
 
-#ifndef VEFFECT_HPP
-#define VEFFECT_HPP
+#ifndef VRASTEREFFECT_HPP
+#define VRASTEREFFECT_HPP
+#include "VEffect.hpp"
+
+
 #include <variant>
 
 #include "Vulkan/Utils/VResrouceGroup/VResourceGroupManager.hpp"
@@ -21,11 +24,10 @@ class VShader;
 class VDevice;
 }  // namespace VulkanCore
 
-inline int EffectIndexCounter = 0;
 
 namespace VulkanUtils {
 
-class VRasterEffect
+class VRasterEffect:public VEffect
 {
   public:
     VRasterEffect(const VulkanCore::VDevice&                          device,
@@ -99,4 +101,4 @@ class VRasterEffect
 };
 }  // namespace VulkanUtils
 
-#endif  //VEFFECT_HPP
+#endif  //VRASTEREFFECT_HPP

--- a/Internal/Vulkan/Utils/VEffect/VRasterEffect.hpp
+++ b/Internal/Vulkan/Utils/VEffect/VRasterEffect.hpp
@@ -74,25 +74,15 @@ class VRasterEffect:public VEffect
 
 
     //=======================================
+    void               BuildEffect() override;
+    vk::PipelineLayout GetPipelineLayout() override;
+    void               BindPipeline(const vk::CommandBuffer& cmdBuffer) override;
+    void               Destroy() override;
 
-    std::string&                  GetName();
-    DescriptorSetTemplateVariant& GetResrouceGroupStructVariant();
-    void                          BuildEffect();
-    vk::PipelineLayout            GetPipelineLayout();
-    void                          BindPipeline(const vk::CommandBuffer& cmdBuffer);
-    void                          Destroy();
-    vk::DescriptorUpdateTemplate& GetUpdateTemplate();
-    unsigned short                EvaluateRenderingOrder();
-    int&                          GetID();
-    EDescriptorLayoutStruct       GetLayoutStructType();
 
   private:
-    const VulkanCore::VDevice&                         m_device;
-    std::shared_ptr<VulkanUtils::VShaderResrouceGroup> m_resourceGroup;
     std::unique_ptr<VulkanCore::VGraphicsPipeline>     m_pipeline;
-    std::string                                        m_name;
     std::optional<VulkanCore::VShader>                 m_shader;
-    int                                                m_ID;
 
   private:
     friend bool operator==(const VRasterEffect& lhs, const VRasterEffect& rhs) { return lhs.m_ID == rhs.m_ID; }

--- a/Internal/Vulkan/Utils/VEffect/VRayTracingEffect.cpp
+++ b/Internal/Vulkan/Utils/VEffect/VRayTracingEffect.cpp
@@ -1,0 +1,8 @@
+//
+// Created by wpsimon09 on 22/04/25.
+//
+
+#include "VRayTracingEffect.hpp"
+
+namespace VulkanUtils {
+} // VulkanUtils

--- a/Internal/Vulkan/Utils/VEffect/VRayTracingEffect.hpp
+++ b/Internal/Vulkan/Utils/VEffect/VRayTracingEffect.hpp
@@ -1,0 +1,16 @@
+//
+// Created by wpsimon09 on 22/04/25.
+//
+
+#ifndef VRAYTRACINGEFFECT_HPP
+#define VRAYTRACINGEFFECT_HPP
+
+namespace VulkanUtils {
+
+class VRayTracingEffect {
+
+};
+
+} // VulkanUtils
+
+#endif //VRAYTRACINGEFFECT_HPP

--- a/Internal/Vulkan/Utils/VEnvLightGenerator/VEnvLightGenerator.cpp
+++ b/Internal/Vulkan/Utils/VEnvLightGenerator/VEnvLightGenerator.cpp
@@ -11,7 +11,7 @@
 #include "Application/Rendering/Mesh/StaticMesh.hpp"
 #include "Application/Rendering/Transformations/Transformations.hpp"
 #include "Vulkan/VulkanCore/Pipeline/VGraphicsPipeline.hpp"
-#include "Vulkan/Utils/VEffect/VEffect.hpp"
+#include "Vulkan/Utils/VEffect/VRasterEffect.hpp"
 #include "Vulkan/Utils/VUniformBufferManager/VUniform.hpp"
 #include "Vulkan/VulkanCore/CommandBuffer/VCommandPool.hpp"
 #include "Vulkan/VulkanCore/Samplers/VSamplers.hpp"
@@ -181,7 +181,7 @@ void VulkanUtils::VEnvLightGenerator::HDRToCubeMap(std::shared_ptr<VulkanCore::V
         // - copies ofcreen buffer the the one of the face of cube
         //=============================================================
         {
-            VEffect hdrToCubeMapEffect(m_device, "HDR Image to cube map", "Shaders/Compiled/HDRToCubeMap.vert.spv",
+            VRasterEffect hdrToCubeMapEffect(m_device, "HDR Image to cube map", "Shaders/Compiled/HDRToCubeMap.vert.spv",
                                        "Shaders/Compiled/HDRToCubeMap.frag.spv",
                                        m_pushDescriptorManager.GetPushDescriptor(EDescriptorLayoutStruct::UnlitSingleTexture));
             hdrToCubeMapEffect.DisableStencil()
@@ -325,7 +325,7 @@ void VulkanUtils::VEnvLightGenerator::CubeMapToIrradiance(std::shared_ptr<Vulkan
         // - copies offcreen buffer the one of the face of cube
         //=============================================================
         {
-            VEffect cubeMapToIrradianceEffect(m_device, "HDR Image to cube map", "Shaders/Compiled/IrradianceMapImportanceSample.vert.spv",
+            VRasterEffect cubeMapToIrradianceEffect(m_device, "HDR Image to cube map", "Shaders/Compiled/IrradianceMapImportanceSample.vert.spv",
                                               "Shaders/Compiled/IrradianceMapImportanceSample.frag.spv",
                                               m_pushDescriptorManager.GetPushDescriptor(EDescriptorLayoutStruct::UnlitSingleTexture));
             cubeMapToIrradianceEffect.DisableStencil()
@@ -463,7 +463,7 @@ void VulkanUtils::VEnvLightGenerator::CubeMapToPrefilter(std::shared_ptr<VulkanC
     // - copies offcreen buffer the one of the face of cube
     //=============================================================
     {
-        VEffect hdrToPrefilterEffect(m_device, "HDR Image to cube map", "Shaders/Compiled/Prefilter.vert.spv",
+        VRasterEffect hdrToPrefilterEffect(m_device, "HDR Image to cube map", "Shaders/Compiled/Prefilter.vert.spv",
                                      "Shaders/Compiled/Prefilter.frag.spv",
                                      m_pushDescriptorManager.GetPushDescriptor(EDescriptorLayoutStruct::UnlitSingleTexture));
         hdrToPrefilterEffect.DisableStencil()
@@ -609,7 +609,7 @@ void VulkanUtils::VEnvLightGenerator::GenerateBRDFLut()
     brdfAttachmentCI.clearValue.color.setFloat32({0.0f, 0.0f, 0.0f, 1.f});
 
     //Create Effect that generates BRDF
-    VEffect brdfEffect(m_device, "BRDF Effect", "Shaders/Compiled/BRDFLut.vert.spv", "Shaders/Compiled/BRDFLut.frag.spv",
+    VRasterEffect brdfEffect(m_device, "BRDF Effect", "Shaders/Compiled/BRDFLut.vert.spv", "Shaders/Compiled/BRDFLut.frag.spv",
                        m_pushDescriptorManager.GetPushDescriptor(EDescriptorLayoutStruct::Empty));
     brdfEffect.SetColourOutputFormat(brdfCI.format)
         .DisableStencil()

--- a/Internal/Vulkan/Utils/VRenderingContext/VRenderingContext.cpp
+++ b/Internal/Vulkan/Utils/VRenderingContext/VRenderingContext.cpp
@@ -5,7 +5,7 @@
 #include "VRenderingContext.hpp"
 
 #include "Vulkan/Global/VulkanStructs.hpp"
-#include "Vulkan/Utils/VEffect/VEffect.hpp"
+#include "Vulkan/Utils/VEffect/VRasterEffect.hpp"
 #include "Application/Rendering/Material/PBRMaterial.hpp"
 
 bool VulkanUtils::RenderContext::CompareByDeptDesc(const VulkanStructs::DrawCallData& DrawCallA,

--- a/Internal/Vulkan/VulkanCore/Pipeline/VGraphicsPipeline.hpp
+++ b/Internal/Vulkan/VulkanCore/Pipeline/VGraphicsPipeline.hpp
@@ -12,7 +12,7 @@
 #include "vector"
 
 namespace VulkanUtils {
-class VEffect;
+class VRasterEffect;
 }
 
 namespace Renderer {
@@ -186,7 +186,7 @@ class VGraphicsPipeline : public VObject
     void EnableBlendingAlpha();
 
   private:
-    friend VulkanUtils::VEffect;
+    friend VulkanUtils::VRasterEffect;
 };
 }  // namespace VulkanCore
 

--- a/Internal/Vulkan/VulkanCore/Pipeline/VRayTracingPipeline.hpp
+++ b/Internal/Vulkan/VulkanCore/Pipeline/VRayTracingPipeline.hpp
@@ -12,11 +12,9 @@
 namespace vk {
 struct PipelineShaderStageCreateInfo;
 }
-namespace VulkanCore::RTX {
-enum ERayTracingStageIndices : int;
-}
+
 namespace VulkanUtils {
-class VEffect;
+class VRasterEffect;
 }
 namespace VulkanCore {
 class VRayTracingShaders;
@@ -82,7 +80,7 @@ private:
 
 
 private:
-  friend class VulkanUtils::VEffect;
+  friend class VulkanUtils::VRasterEffect;
 };
 
 } // RTX

--- a/Internal/VulkanRtx.cpp
+++ b/Internal/VulkanRtx.cpp
@@ -55,7 +55,7 @@
 #include "Editor/UIContext/UIContext.hpp"
 #include "Vulkan/Global/GlobalState.hpp"
 #include "Vulkan/Utils/TransferOperationsManager/VTransferOperationsManager.hpp"
-#include "Vulkan/Utils/VEffect/VEffect.hpp"
+#include "Vulkan/Utils/VEffect/VRasterEffect.hpp"
 #include "Vulkan/Utils/VMeshDataManager/MeshDataManager.hpp"
 
 #include "Vulkan/Utils/VEnvLightGenerator/VEnvLightGenerator.hpp"

--- a/Shaders/compileSlang.py
+++ b/Shaders/compileSlang.py
@@ -65,7 +65,7 @@ def compile_ray_tracing_shaders(dir, verbose):
             compile_shader(
                 [SLANGC_PATH, "-target", "spirv", "-stage", "raygeneration" ,"-I","Source/Modules","-entry", "rayGenMain",
                  "-o", f"Compiled/{name}.rgen.spv", path],
-                f"✓ {name}.vert",
+                f"✓ {name}.raygen.slagn",
                 f"✗ Failed: {name}.vert",
                 verbose
             )
@@ -73,7 +73,7 @@ def compile_ray_tracing_shaders(dir, verbose):
             compile_shader(
                 [SLANGC_PATH, "-target", "spirv", "-stage", "miss" ,"-I","Source/Modules","-entry", "missMain",
                  "-o", f"Compiled/{name}.miss.spv", path],
-                f"✓ {name}.frag",
+                f"✓ {name}.miss.slang",
                 f"✗ Failed: {name}.frag",
                 verbose
             )
@@ -82,12 +82,11 @@ def compile_ray_tracing_shaders(dir, verbose):
             compile_shader(
                 [SLANGC_PATH, "-target", "spirv", "-stage", "closesthit" ,"-I","Source/Modules", "-entry", "closestHitMain",
                  "-o", f"Compiled/{name}.chit.spv", path],
-                f"✓ {name}.frag",
+                f"✓ {name}.chit.slang",
                 f"✗ Failed: {name}.frag",
                 verbose
             )
  
-
 def main():
     parser = argparse.ArgumentParser(description="Slang Shader Compiler")
     parser.add_argument('--verbose', action='store_true', help='Enable verbose output')

--- a/imgui.ini
+++ b/imgui.ini
@@ -102,7 +102,7 @@ Collapsed=0
 
 [Window][Index]
 Pos=0,22
-Size=1920,1109
+Size=1000,778
 Collapsed=0
 
 [Window][Scene graph]
@@ -129,7 +129,7 @@ DockId=0x0000000F,0
 
 [Window][ Scene view port]
 Pos=0,44
-Size=1411,809
+Size=491,478
 Collapsed=0
 DockId=0x00000010,0
 
@@ -140,8 +140,8 @@ Collapsed=0
 DockId=0x00000013,0
 
 [Window][ Details]
-Pos=1413,586
-Size=507,545
+Pos=493,421
+Size=507,379
 Collapsed=0
 DockId=0x00000015,0
 
@@ -152,8 +152,8 @@ Collapsed=0
 DockId=0x00000012,1
 
 [Window][ Rendering options]
-Pos=958,855
-Size=453,276
+Pos=334,524
+Size=157,276
 Collapsed=0
 DockId=0x00000019,1
 
@@ -179,14 +179,14 @@ Collapsed=0
 DockId=0x00000017,0
 
 [Window][ Console]
-Pos=0,855
-Size=956,276
+Pos=0,524
+Size=332,276
 Collapsed=0
 DockId=0x00000018,0
 
 [Window][ Scene graph]
-Pos=1413,44
-Size=507,540
+Pos=493,44
+Size=507,375
 Collapsed=0
 DockId=0x00000014,0
 
@@ -211,8 +211,8 @@ Size=758,805
 Collapsed=0
 
 [Window][ ContentBrowser]
-Pos=958,855
-Size=453,276
+Pos=334,524
+Size=157,276
 Collapsed=0
 DockId=0x00000019,0
 
@@ -760,7 +760,7 @@ Column 0  Sort=0v
 
 [Docking][Data]
 DockNode                ID=0x00000003 Pos=-7,162 Size=1246,704 Selected=0x5E5F7166
-DockSpace               ID=0x80E0A261 Window=0x5FDD4DE6 Pos=0,44 Size=1920,1087 Split=X Selected=0x4E1DE355
+DockSpace               ID=0x80E0A261 Window=0x5FDD4DE6 Pos=0,44 Size=1000,756 Split=X Selected=0x4E1DE355
   DockNode              ID=0x0000001A Parent=0x80E0A261 SizeRef=1411,999 Split=X
     DockNode            ID=0x00000012 Parent=0x0000001A SizeRef=1580,1087 Split=X
       DockNode          ID=0x0000000E Parent=0x00000012 SizeRef=411,578 Split=X

--- a/imgui.ini
+++ b/imgui.ini
@@ -102,7 +102,7 @@ Collapsed=0
 
 [Window][Index]
 Pos=0,22
-Size=1000,778
+Size=1920,1109
 Collapsed=0
 
 [Window][Scene graph]
@@ -129,7 +129,7 @@ DockId=0x0000000F,0
 
 [Window][ Scene view port]
 Pos=0,44
-Size=491,478
+Size=1411,809
 Collapsed=0
 DockId=0x00000010,0
 
@@ -140,8 +140,8 @@ Collapsed=0
 DockId=0x00000013,0
 
 [Window][ Details]
-Pos=493,421
-Size=507,379
+Pos=1413,586
+Size=507,545
 Collapsed=0
 DockId=0x00000015,0
 
@@ -152,8 +152,8 @@ Collapsed=0
 DockId=0x00000012,1
 
 [Window][ Rendering options]
-Pos=334,524
-Size=157,276
+Pos=958,855
+Size=453,276
 Collapsed=0
 DockId=0x00000019,1
 
@@ -179,14 +179,14 @@ Collapsed=0
 DockId=0x00000017,0
 
 [Window][ Console]
-Pos=0,524
-Size=332,276
+Pos=0,855
+Size=956,276
 Collapsed=0
 DockId=0x00000018,0
 
 [Window][ Scene graph]
-Pos=493,44
-Size=507,375
+Pos=1413,44
+Size=507,540
 Collapsed=0
 DockId=0x00000014,0
 
@@ -211,8 +211,8 @@ Size=758,805
 Collapsed=0
 
 [Window][ ContentBrowser]
-Pos=334,524
-Size=157,276
+Pos=958,855
+Size=453,276
 Collapsed=0
 DockId=0x00000019,0
 
@@ -754,9 +754,13 @@ Column 0  Sort=0v
 RefScale=16
 Column 0  Sort=0v
 
+[Table][0x5FFA1DAC,4]
+RefScale=16
+Column 0  Sort=0v
+
 [Docking][Data]
 DockNode                ID=0x00000003 Pos=-7,162 Size=1246,704 Selected=0x5E5F7166
-DockSpace               ID=0x80E0A261 Window=0x5FDD4DE6 Pos=0,44 Size=1000,756 Split=X Selected=0x4E1DE355
+DockSpace               ID=0x80E0A261 Window=0x5FDD4DE6 Pos=0,44 Size=1920,1087 Split=X Selected=0x4E1DE355
   DockNode              ID=0x0000001A Parent=0x80E0A261 SizeRef=1411,999 Split=X
     DockNode            ID=0x00000012 Parent=0x0000001A SizeRef=1580,1087 Split=X
       DockNode          ID=0x0000000E Parent=0x00000012 SizeRef=411,578 Split=X


### PR DESCRIPTION
differentiated between `RasterEffects` that are going to be used in rasterisation pipeline and `RayTracingEffect` that on the other hand are going to be used in the RayTracingPipeline

HUGE TODO: decouple mesh, material and effect to single `Renderable` class since now mesh has material which has effect but this was rather dumb and naive design choice