### PR TITLE
Application state

### DIFF
--- a/Internal/Application/ApplicationState/ApplicationState.cpp
+++ b/Internal/Application/ApplicationState/ApplicationState.cpp
@@ -8,6 +8,7 @@
 namespace ApplicationCore {
 ApplicationState::ApplicationState() {}
 
+
 void ApplicationState::Update() {}
 
 void ApplicationState::Reset()

--- a/Internal/Application/ApplicationState/ApplicationState.cpp
+++ b/Internal/Application/ApplicationState/ApplicationState.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "ApplicationState.hpp"
+#include "Vulkan/Utils/VUniformBufferManager/UnifromsRegistry.hpp"
 
 namespace ApplicationCore {
 ApplicationState::ApplicationState() {}
@@ -13,15 +14,59 @@ void ApplicationState::Reset()
 {
     m_windowResized = false;
 }
-LightStructs::SceneLightInfo& ApplicationState::GetSceneLightInfo() { return *m_sceneLight;}
-void                          ApplicationState::pSetSceneLightInfo(LightStructs::SceneLightInfo* pSceneLight) {m_sceneLight = pSceneLight;}
-SceneData&                    ApplicationState::GetSceneData() {return *m_sceneData;}
-void                          ApplicationState::pSetSceneData(SceneData* pSceneData) {m_sceneData = pSceneData;}
-SceneUpdateFlags&             ApplicationState::GetSceneUpdateFlags() { return *m_sceneUpdateFlags;}
-void                          ApplicationState::pSetSceneUpdateFlags(SceneUpdateFlags* sceneUpdateFlags) { m_sceneUpdateFlags = sceneUpdateFlags;}
-GlobalRenderingInfo&          ApplicationState::GetGlobalRenderingInfo() { return *m_globalRenderingInfo;}
-void                          ApplicationState::pSetGlobalRenderingInfo(GlobalRenderingInfo* pGlobalRenderingInfo) {m_globalRenderingInfo = pGlobalRenderingInfo;}
-bool&                         ApplicationState::IsWindowResized() {return m_windowResized;}
-void                          ApplicationState::SetIsWindowResized(bool windowResized) {m_windowResized = windowResized;}
+LightStructs::SceneLightInfo& ApplicationState::GetSceneLightInfo()
+{
+    return *m_sceneLight;
+}
+void ApplicationState::pSetSceneLightInfo(LightStructs::SceneLightInfo* pSceneLight)
+{
+    m_sceneLight = pSceneLight;
+}
+
+SceneData& ApplicationState::GetSceneData()
+{
+    return *m_sceneData;
+}
+void ApplicationState::pSetSceneData(SceneData* pSceneData)
+{
+    m_sceneData = pSceneData;
+}
+
+SceneUpdateFlags& ApplicationState::GetSceneUpdateFlags()
+{
+    return *m_sceneUpdateFlags;
+}
+void ApplicationState::pSetSceneUpdateFlags(SceneUpdateFlags* sceneUpdateFlags)
+{
+    m_sceneUpdateFlags = sceneUpdateFlags;
+}
+
+GlobalRenderingInfo& ApplicationState::GetGlobalRenderingInfo()
+{
+    return *m_globalRenderingInfo;
+}
+void ApplicationState::pSetGlobalRenderingInfo(GlobalRenderingInfo* pGlobalRenderingInfo)
+{
+    m_globalRenderingInfo = pGlobalRenderingInfo;
+}
+
+PostProcessingParameters& ApplicationState::GetPostProcessingParameters()
+{
+    return *m_postProcessingParameters;
+}
+
+void ApplicationState::pSetPostProcessingParameters(PostProcessingParameters* postProcessingParameters)
+{
+    m_postProcessingParameters = postProcessingParameters;
+}
+
+bool& ApplicationState::IsWindowResized()
+{
+    return m_windowResized;
+}
+void ApplicationState::SetIsWindowResized(bool windowResized)
+{
+    m_windowResized = windowResized;
+}
 
 }  // namespace ApplicationCore

--- a/Internal/Application/ApplicationState/ApplicationState.hpp
+++ b/Internal/Application/ApplicationState/ApplicationState.hpp
@@ -6,6 +6,7 @@
 #define APPLICATIONSTATE_HPP
 
 
+#include "Vulkan/Utils/VUniformBufferManager/UnifromsRegistry.hpp"
 struct GlobalRenderingInfo;
 struct SceneUpdateFlags;
 namespace LightStructs {
@@ -26,27 +27,31 @@ class ApplicationState
 
     void Reset();
 
-    LightStructs::SceneLightInfo&  GetSceneLightInfo();
-    void                           pSetSceneLightInfo(LightStructs::SceneLightInfo* pSceneLight);
+    LightStructs::SceneLightInfo& GetSceneLightInfo();
+    void                          pSetSceneLightInfo(LightStructs::SceneLightInfo* pSceneLight);
 
-    SceneData&                    GetSceneData();
-    void                           pSetSceneData(SceneData* pSceneData);
+    SceneData& GetSceneData();
+    void       pSetSceneData(SceneData* pSceneData);
 
-    SceneUpdateFlags&                GetSceneUpdateFlags();
-    void                           pSetSceneUpdateFlags(SceneUpdateFlags* sceneUpdateFlags);
+    SceneUpdateFlags& GetSceneUpdateFlags();
+    void              pSetSceneUpdateFlags(SceneUpdateFlags* sceneUpdateFlags);
 
-    GlobalRenderingInfo&          GetGlobalRenderingInfo();
-    void                           pSetGlobalRenderingInfo(GlobalRenderingInfo* pGlobalRenderingInfo);
+    GlobalRenderingInfo& GetGlobalRenderingInfo();
+    void                 pSetGlobalRenderingInfo(GlobalRenderingInfo* pGlobalRenderingInfo);
 
-    bool&                          IsWindowResized();
-    void                           SetIsWindowResized(bool windowResized);
+    PostProcessingParameters& GetPostProcessingParameters();
+    void                      pSetPostProcessingParameters(PostProcessingParameters* pPostProcessingParameters);
+
+    bool& IsWindowResized();
+    void  SetIsWindowResized(bool windowResized);
 
   private:
-    LightStructs::SceneLightInfo* m_sceneLight          = nullptr;
-    SceneData*                    m_sceneData           = nullptr;
-    SceneUpdateFlags*             m_sceneUpdateFlags    = nullptr;
-    GlobalRenderingInfo*          m_globalRenderingInfo = nullptr;
-    bool                          m_windowResized       = false;
+    LightStructs::SceneLightInfo* m_sPceneLight              = nullptr;
+    SceneData*                    m_sceneData                = nullptr;
+    SceneUpdateFlags*             m_sceneUpdateFlags         = nullptr;
+    GlobalRenderingInfo*          m_globalRenderingInfo      = nullptr;
+    PostProcessingParameters*     m_postProcessingParameters = nullptr;
+    bool                          m_windowResized            = false;
 };
 
 }  // namespace ApplicationCore

--- a/Internal/Application/ApplicationState/ApplicationState.hpp
+++ b/Internal/Application/ApplicationState/ApplicationState.hpp
@@ -46,7 +46,7 @@ class ApplicationState
     void  SetIsWindowResized(bool windowResized);
 
   private:
-    LightStructs::SceneLightInfo* m_sPceneLight              = nullptr;
+    LightStructs::SceneLightInfo* m_sceneLight               = nullptr;
     SceneData*                    m_sceneData                = nullptr;
     SceneUpdateFlags*             m_sceneUpdateFlags         = nullptr;
     GlobalRenderingInfo*          m_globalRenderingInfo      = nullptr;

--- a/Internal/Application/Client.cpp
+++ b/Internal/Application/Client.cpp
@@ -29,6 +29,9 @@ Client::Client()
     : m_globalRenderingData()
 {
     m_applicationState = std::make_unique<ApplicationCore::ApplicationState>();
+
+    m_applicationState->pSetGlobalRenderingInfo(&m_globalRenderingData);
+    m_applicationState->pSetPostProcessingParameters(&m_postProcessingParameters);
 }
 
 void Client::Init()
@@ -99,12 +102,12 @@ void Client::UpdateCamera(CameraUpdateInfo& cameraUpdateInfo)
     m_globalRenderingData.view        = m_camera->GetViewMatrix();
     m_globalRenderingData.inverseView = m_camera->GetInverseViewMatrix();
     m_globalRenderingData.inverseProj = m_camera->GetinverseProjectionMatrix();
-    m_globalRenderingData.screenSize  = {GlobalVariables::RenderTargetResolutionWidth, GlobalVariables::RenderTargetResolutionHeight};
-    m_globalRenderingData.viewParams = glm::vec4(m_camera->GetCameraPlaneWidthAndHeight(), m_camera->GetNearPlane(), m_camera->GetFarPlane());
+    m_globalRenderingData.screenSize = {GlobalVariables::RenderTargetResolutionWidth, GlobalVariables::RenderTargetResolutionHeight};
+    m_globalRenderingData.viewParams =
+        glm::vec4(m_camera->GetCameraPlaneWidthAndHeight(), m_camera->GetNearPlane(), m_camera->GetFarPlane());
     m_globalRenderingData.reccursionDepth = GlobalVariables::RenderingOptions::MaxRecursionDepth;
-    m_globalRenderingData.raysPerPixel = GlobalVariables::RenderingOptions::RaysPerPixel;
-    m_globalRenderingData.cameraPosition = glm::vec4(m_camera->GetPosition(), 1.0f);
-
+    m_globalRenderingData.raysPerPixel    = GlobalVariables::RenderingOptions::RaysPerPixel;
+    m_globalRenderingData.cameraPosition  = glm::vec4(m_camera->GetPosition(), 1.0f);
 }
 
 void Client::UpdateClient(ClientUpdateInfo& lightUpdateInfo)

--- a/Internal/Application/Client.hpp
+++ b/Internal/Application/Client.hpp
@@ -55,13 +55,15 @@ class Client
 
     ApplicationCore::AssetsManager& GetAssetsManager() const { return *m_assetsManager; }
 
-    GlobalRenderingInfo&          GetGlobalDataUpdateInformation() { return m_globalRenderingData; }
+    GlobalRenderingInfo&    GetGlobalDataUpdateInformation() { return m_globalRenderingData; }
     ApplicationCore::Scene& GetScene() const { return *m_scene; };
     ;
     ApplicationCore::GLTFLoader&   GetGLTFLoader() const { return *m_gltfLoader; };
     ApplicationCore::GLTFExporter& GetGLTFExporter() const { return *m_gltfExporter; };
 
-    PostProcessingParameters&      GetPostProcessingParameters() {return m_postProcessingParameters;}
+    ApplicationCore::ApplicationState& GetApplicationState() { return *m_applicationState; }
+
+    PostProcessingParameters& GetPostProcessingParameters() { return m_postProcessingParameters; }
 
     void Update();
     void UpdateCamera(CameraUpdateInfo& cameraUpdateInfo);
@@ -81,9 +83,9 @@ class Client
     std::unique_ptr<ApplicationCore::GLTFExporter>                  m_gltfExporter;
     std::unique_ptr<ApplicationCore::ApplicationState>              m_applicationState;
 
-    GlobalRenderingInfo m_globalRenderingData;
+    GlobalRenderingInfo      m_globalRenderingData;
     PostProcessingParameters m_postProcessingParameters;
-    bool          m_isRTXOn = false;
+    bool                     m_isRTXOn = false;
 };
 
 

--- a/Internal/Application/Rendering/Scene/Scene.cpp
+++ b/Internal/Application/Rendering/Scene/Scene.cpp
@@ -23,6 +23,7 @@
 #include "Vulkan/VulkanCore/RayTracing/VRayTracingBuilderKhr.hpp"
 #include "Vulkan/VulkanCore/RayTracing/VRayTracingBuilderKhrHelpers.hpp"
 #include "Vulkan/VulkanCore/RayTracing/VRayTracingStructs.hpp"
+#include "Application/ApplicationState/ApplicationState.hpp"
 
 namespace ApplicationCore {
 
@@ -31,10 +32,13 @@ namespace ApplicationCore {
 //=============================================================================
 Scene::Scene(ApplicationState& applicationState, AssetsManager& assetsManager, Camera& camera)
     : m_applicationState(applicationState)
-    ,m_assetsManager(assetsManager)
+    , m_assetsManager(assetsManager)
     , m_sceneStatistics()
     , m_camera(camera)
 {
+    m_applicationState.pSetSceneLightInfo(&m_sceneLightInfo);
+    m_applicationState.pSetSceneData(&m_sceneData);
+    m_applicationState.pSetSceneUpdateFlags(&m_sceneUpdateFlags);
 }
 
 void Scene::Init()

--- a/Internal/Vulkan/Renderer/Renderers/RayTracing/RayTracer.cpp
+++ b/Internal/Vulkan/Renderer/Renderers/RayTracing/RayTracer.cpp
@@ -83,7 +83,6 @@ RayTracer::RayTracer(const VulkanCore::VDevice&           device,
 }
 
 void RayTracer::TraceRays(const VulkanCore::VCommandBuffer&         cmdBuffer,
-                          const SceneUpdateFlags&                   sceneUpdateFlags,
                           const VulkanUtils::VUniformBufferManager& unifromBufferManager,
                           int                                       currentFrame)
 {

--- a/Internal/Vulkan/Renderer/Renderers/RayTracing/RayTracer.hpp
+++ b/Internal/Vulkan/Renderer/Renderers/RayTracing/RayTracer.hpp
@@ -45,20 +45,19 @@ namespace Renderer {
 class RayTracer
 {
   public:
-    RayTracer(const VulkanCore::VDevice& device,
-              ApplicationCore::EffectsLibrary& effectsLibrary,
+    RayTracer(const VulkanCore::VDevice&           device,
+              ApplicationCore::EffectsLibrary&     effectsLibrary,
               VulkanUtils::VRayTracingDataManager& rtxDataManager,
-              int width,
-              int height);
+              int                                  width,
+              int                                  height);
 
     void TraceRays(const VulkanCore::VCommandBuffer&         cmdBuffer,
-                   const SceneUpdateFlags&                   sceneUpdateFlags,
                    const VulkanUtils::VUniformBufferManager& unifromBufferManager,
                    int                                       currentFrame);
 
     void ProcessResize(int newWidth, int newHeight);
 
-    VulkanCore::VImage2 &  GetRenderedImage(int currentFrameIndex);
+    VulkanCore::VImage2& GetRenderedImage(int currentFrameIndex);
 
     void Destroy();
 
@@ -66,12 +65,11 @@ class RayTracer
     const VulkanCore::VDevice&           m_device;
     VulkanUtils::VRayTracingDataManager& m_rtxDataManager;
 
-    std::shared_ptr<VulkanUtils::VEffect> m_rtxEffect;
+    std::shared_ptr<VulkanUtils::VEffect>       m_rtxEffect;
     std::unique_ptr<VulkanUtils::VRasterEffect> m_accumulationEffect;
 
     std::vector<std::unique_ptr<VulkanCore::VImage2>> m_resultImage;
     std::unique_ptr<VulkanCore::VImage2>              m_accumulationResultImage;
-
 };
 
 }  // namespace Renderer

--- a/Internal/Vulkan/Renderer/Renderers/RenderingSystem.hpp
+++ b/Internal/Vulkan/Renderer/Renderers/RenderingSystem.hpp
@@ -13,6 +13,7 @@
 #include <glm/fwd.hpp>
 
 // Project Includes
+#include "Application/ApplicationState/ApplicationState.hpp"
 #include "Editor/Views/UserInterface/IUserInterfaceElement.hpp"
 #include "Vulkan/Global/VulkanStructs.hpp"
 #include "Vulkan/Utils/VRenderingContext/VRenderingContext.hpp"
@@ -27,38 +28,38 @@ struct SceneData;
 }
 // Forward Declarations
 namespace VulkanCore {
-    class VDevice;
-    class VSwapChain;
-    class VPipelineManager;
-    class VTimelineSemaphore;
-    template<typename T>
-    class VSyncPrimitive;
-}
+class VDevice;
+class VSwapChain;
+class VPipelineManager;
+class VTimelineSemaphore;
+template <typename T>
+class VSyncPrimitive;
+}  // namespace VulkanCore
 
 namespace VulkanUtils {
-    class UIContext;
-    class VEnvLightGenerator;
-    class VUniformBufferManager;
-    class VResourceGroupManager;
-    class VRayTracingDataManager;
-    struct RenderContext;
-}
+class UIContext;
+class VEnvLightGenerator;
+class VUniformBufferManager;
+class VResourceGroupManager;
+class VRayTracingDataManager;
+struct RenderContext;
+}  // namespace VulkanUtils
 
 namespace VulkanCore::RTX {
-    struct BLASInput;
+struct BLASInput;
 }
 
 namespace Renderer {
 class PostProcessingSystem;
 class RayTracer;
-    class ForwardRenderer;
-    class UserInterfaceRenderer;
-}
+class ForwardRenderer;
+class UserInterfaceRenderer;
+}  // namespace Renderer
 
 namespace VEditor {
-    class RenderingOptions;
-    class UIContext;
-}
+class RenderingOptions;
+class UIContext;
+}  // namespace VEditor
 
 struct GlobalRenderingInfo;
 
@@ -66,29 +67,29 @@ namespace Renderer {
 
 class RenderingSystem
 {
-public:
-    RenderingSystem(const VulkanCore::VulkanInstance&         instance,
-                    const VulkanCore::VDevice&                device,
+  public:
+    RenderingSystem(const VulkanCore::VulkanInstance&    instance,
+                    const VulkanCore::VDevice&           device,
                     VulkanUtils::VRayTracingDataManager& rayTracingDataManager,
-                     VulkanUtils::VUniformBufferManager& uniformBufferManager,
-                    ApplicationCore::EffectsLibrary&          effectsLybrary,
-                    VulkanCore::VDescriptorLayoutCache&       descLayoutCache,
-                    VEditor::UIContext&                       uiContext);
+                    VulkanUtils::VUniformBufferManager&  uniformBufferManager,
+                    ApplicationCore::EffectsLibrary&     effectsLybrary,
+                    VulkanCore::VDescriptorLayoutCache&  descLayoutCache,
+                    VEditor::UIContext&                  uiContext);
 
     void Init();
-    void Render(bool resizeSwapChain, LightStructs::SceneLightInfo& sceneLightInfo,ApplicationCore::SceneData& sceneData, GlobalRenderingInfo& globalUniformUpdateInfo, PostProcessingParameters& postProcessingParameters, SceneUpdateFlags& sceneUpdateFlags);
+    void Render(ApplicationCore::ApplicationState& applicationState);
     void Update();
     void Destroy();
 
-    ForwardRenderer&                         GetSceneRenderer() { return *m_forwardRenderer; };
-    VulkanUtils::RenderContext*            GetRenderContext() { return &m_renderContext; }
+    ForwardRenderer&            GetSceneRenderer() { return *m_forwardRenderer; };
+    VulkanUtils::RenderContext* GetRenderContext() { return &m_renderContext; }
 
-private:
+  private:
     // Core Vulkan references
-    const VulkanCore::VDevice&                m_device;
-     VulkanUtils::VUniformBufferManager& m_uniformBufferManager;
-    ApplicationCore::EffectsLibrary*          m_effectsLibrary;
-    VEditor::UIContext&                       m_uiContext;
+    const VulkanCore::VDevice&          m_device;
+    VulkanUtils::VUniformBufferManager& m_uniformBufferManager;
+    ApplicationCore::EffectsLibrary*    m_effectsLibrary;
+    VEditor::UIContext&                 m_uiContext;
 
     // Scene state
     LightStructs::SceneLightInfo* m_sceneLightInfo = nullptr;
@@ -103,28 +104,28 @@ private:
     std::unique_ptr<VulkanUtils::VEnvLightGenerator> m_envLightGenerator;
 
     // Swapchain and Command Buffers
-    std::unique_ptr<VulkanCore::VSwapChain>                    m_swapChain;
-    std::unique_ptr<VulkanCore::VCommandPool>                  m_renderingCommandPool;
-    std::vector<std::unique_ptr<VulkanCore::VCommandBuffer>>   m_renderingCommandBuffers;
+    std::unique_ptr<VulkanCore::VSwapChain>                  m_swapChain;
+    std::unique_ptr<VulkanCore::VCommandPool>                m_renderingCommandPool;
+    std::vector<std::unique_ptr<VulkanCore::VCommandBuffer>> m_renderingCommandBuffers;
 
     // Synchronization
     std::vector<std::unique_ptr<VulkanCore::VSyncPrimitive<vk::Semaphore>>> m_imageAvailableSemaphores;
     std::vector<std::unique_ptr<VulkanCore::VSyncPrimitive<vk::Semaphore>>> m_ableToPresentSemaphore;
     std::vector<std::unique_ptr<VulkanCore::VTimelineSemaphore>>            m_renderingTimeLine;
-    VulkanCore::VTimelineSemaphore&                                           m_transferSemapohore;
+    VulkanCore::VTimelineSemaphore&                                         m_transferSemapohore;
 
 
     // Render context
-    VulkanUtils::RenderContext m_renderContext;
+    VulkanUtils::RenderContext           m_renderContext;
     VulkanStructs::PostProcessingContext m_postProcessingContext;
     VulkanUtils::VRayTracingDataManager& m_rayTracingDataManager;
 
     // State
-    uint32_t m_currentImageIndex = 0;
-    uint32_t m_currentFrameIndex = 0;
-    uint64_t m_frameCount = 0;
+    uint32_t m_currentImageIndex      = 0;
+    uint32_t m_currentFrameIndex      = 0;
+    uint64_t m_frameCount             = 0;
     uint64_t m_accumulatedFramesCount = 0;
-    bool     m_isRayTracing = false;
+    bool     m_isRayTracing           = false;
 
     VulkanCore::VDescriptorLayoutCache& m_descLayoutCache;
 

--- a/Internal/VulkanRtx.cpp
+++ b/Internal/VulkanRtx.cpp
@@ -214,6 +214,8 @@ void Application::Update()
         m_rayTracingDataManager->UpdateAS(blasInput);
         Utils::Logger::LogInfo("Updating AS");
     }
+
+    m_client->GetApplicationState().SetIsWindowResized(m_windowManager->GetHasResized());
 }
 
 void Application::Render()
@@ -224,9 +226,7 @@ void Application::Render()
 
     m_editor->Render();
 
-    m_renderingSystem->Render(m_windowManager->GetHasResized(), m_client->GetScene().GetSceneLightInfo(),
-                              m_client->GetScene().GetSceneData(), m_client->GetGlobalDataUpdateInformation(),
-                              m_client->GetPostProcessingParameters(), m_client->GetScene().GetSceneUpdateFlags());
+    m_renderingSystem->Render(m_client->GetApplicationState());
 
     m_renderingSystem->Update();
 }
@@ -235,6 +235,7 @@ void Application::PostRender()
 {
     m_vulkanDevice->GetTransferOpsManager().ClearResources();
     m_client->GetScene().Reset();
+    m_client->GetApplicationState().Reset();
 }
 
 Application::~Application()


### PR DESCRIPTION
very small refactoring PR that creates `ApplicationState` class which holds all of the state required by the rendering system to draw the image. 

from 

```
renderer->Render(global_data , light_data, scene_list, draw_calls) 
``` 

to 

```
renderer->Render(&appState, draw_calls) 

```