### PR TITLE
Sync2 submit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,6 +243,8 @@ set(SOURCES
         Internal/Vulkan/Renderer/Renderers/RenderPass/PostProcessing.hpp
         Internal/Vulkan/VulkanCore/Buffer/VGrowableBuffer.cpp
         Internal/Vulkan/VulkanCore/Buffer/VGrowableBuffer.hpp
+        Internal/Vulkan/VulkanCore/Synchronization/VTimelineSemaphore2.cpp
+        Internal/Vulkan/VulkanCore/Synchronization/VTimelineSemaphore2.hpp
 
 )
 

--- a/Internal/Vulkan/Global/GlobalVulkanEnums.hpp
+++ b/Internal/Vulkan/Global/GlobalVulkanEnums.hpp
@@ -71,5 +71,13 @@ enum EShaderBindingGroup
     AverageLuminance
 };
 
+enum EFrameStages {
+    Uninitialized = 0,
+    TransferFinish,
+    RenderFinish,
+    SafeToBegin,
+    NumStages
+};
+
 
 #endif  //GLOBALVULKANENUMS_HPP

--- a/Internal/Vulkan/Renderer/Renderers/RenderingSystem.cpp
+++ b/Internal/Vulkan/Renderer/Renderers/RenderingSystem.cpp
@@ -145,7 +145,6 @@ void RenderingSystem::CanStartRecording() {
     if (m_frameCount >= GlobalVariables::MAX_FRAMES_IN_FLIGHT) {
         m_frameTimeLine[m_currentFrameIndex]->CpuWaitIdle(EFrameStages::SafeToBegin);
         m_frameTimeLine[m_currentFrameIndex]->Frame++;
-
     }
 }
 
@@ -188,6 +187,7 @@ void RenderingSystem::Update(ApplicationCore::ApplicationState& applicationState
     // IMPORTANT: this sends all data accumulated over the frame to the GPU
     applicationState.GetGlobalRenderingInfo().isRayTracing = static_cast<int>(m_isRayTracing);
     m_uniformBufferManager.Update(m_currentFrameIndex, applicationState, m_renderContext.GetAllDrawCall());
+
     m_device.GetTransferOpsManager().UpdateGPU(*m_frameTimeLine[m_currentFrameIndex]);
 
 

--- a/Internal/Vulkan/Renderer/Renderers/RenderingSystem.cpp
+++ b/Internal/Vulkan/Renderer/Renderers/RenderingSystem.cpp
@@ -332,11 +332,11 @@ void RenderingSystem::Render(ApplicationCore::ApplicationState& applicationState
     * and informing presentation engine and UI renderer that the presentation can happen since rendering is done
     */
     vk::SemaphoreSubmitInfo ableToPresentSubmitInfo = {
-        m_ableToPresentSemaphore[m_currentFrameIndex]->GetSyncPrimitive(), {}, vk::PipelineStageFlagBits2::eAllCommands};
+        m_ableToPresentSemaphore[m_currentFrameIndex]->GetSyncPrimitive(), {}, vk::PipelineStageFlagBits2::eNone};
 
     std::vector<vk::SemaphoreSubmitInfo> signalSemaphores = {
         // rendering timeline will signal 8 which means that new frame can start exectuing
-        m_frameTimeLine[m_currentFrameIndex]->GetSemaphoreSignalSubmitInfo(EFrameStages::SafeToBegin, vk::PipelineStageFlagBits2::eAllCommands),
+        m_frameTimeLine[m_currentFrameIndex]->GetSemaphoreSignalSubmitInfo(EFrameStages::SafeToBegin, vk::PipelineStageFlagBits2::eNone),
         // able to present semaphore should be singaled once rendering is finished
         ableToPresentSubmitInfo};
 
@@ -349,6 +349,7 @@ void RenderingSystem::Render(ApplicationCore::ApplicationState& applicationState
 
     m_frameCount++;
     m_device.CurrentFrame = m_frameCount;
+    m_device.CurrentFrameInFlight = m_currentFrameIndex;
 
     m_renderContext.hasSceneChanged = false;
 }

--- a/Internal/Vulkan/Renderer/Renderers/RenderingSystem.cpp
+++ b/Internal/Vulkan/Renderer/Renderers/RenderingSystem.cpp
@@ -144,6 +144,8 @@ void RenderingSystem::Init()
 void RenderingSystem::CanStartRecording() {
     if (m_frameCount >= GlobalVariables::MAX_FRAMES_IN_FLIGHT) {
         m_frameTimeLine[m_currentFrameIndex]->CpuWaitIdle(EFrameStages::SafeToBegin);
+        m_frameTimeLine[m_currentFrameIndex]->Frame++;
+
     }
 }
 
@@ -347,15 +349,11 @@ void RenderingSystem::Render(ApplicationCore::ApplicationState& applicationState
 
     m_currentFrameIndex   = (m_currentFrameIndex + 1) % GlobalVariables::MAX_FRAMES_IN_FLIGHT;
 
+    m_device.CurrentFrameInFlight = m_currentFrameIndex;
+    m_renderContext.hasSceneChanged = false;
+
 
     m_frameCount++;
-    m_device.CurrentFrameInFlight = m_currentFrameIndex;
-
-    if (m_frameCount >= GlobalVariables::MAX_FRAMES_IN_FLIGHT) {
-        m_device.CurrentFrame++;
-    }
-
-    m_renderContext.hasSceneChanged = false;
 }
 
 

--- a/Internal/Vulkan/Renderer/Renderers/RenderingSystem.cpp
+++ b/Internal/Vulkan/Renderer/Renderers/RenderingSystem.cpp
@@ -150,10 +150,12 @@ void RenderingSystem::Update(ApplicationCore::ApplicationState& applicationState
     m_frameTimeLine[m_currentFrameIndex]->CpuWaitIdle(8);
 
     m_acquiredImage = VulkanUtils::SwapChainNextImageKHRWrapper(m_device, *m_swapChain, UINT64_MAX,
-                                                                *m_imageAvailableSemaphores[m_currentFrameIndex], nullptr);
+
+    *m_imageAvailableSemaphores[m_currentFrameIndex], nullptr);
+
+    m_renderingCommandBuffers[m_currentFrameIndex]->Reset();
 
     m_frameTimeLine[m_currentFrameIndex]->Reset();
-    m_renderingCommandBuffers[m_currentFrameIndex]->Reset();
     m_frameCount++;
 
     m_sceneLightInfo = &applicationState.GetSceneLightInfo();
@@ -229,7 +231,7 @@ void RenderingSystem::Update(ApplicationCore::ApplicationState& applicationState
 void RenderingSystem::Render(ApplicationCore::ApplicationState& applicationState)
 {
 
-    //=================================================
+    //=================================================2080204129
     // GET SWAP IMAGE INDEX
     //=================================================
     auto imageIndex = m_acquiredImage;
@@ -343,6 +345,7 @@ void RenderingSystem::Render(ApplicationCore::ApplicationState& applicationState
                           m_ableToPresentSemaphore[m_currentImageIndex]->GetSyncPrimitive());
 
     m_currentFrameIndex = (m_currentFrameIndex + 1) % GlobalVariables::MAX_FRAMES_IN_FLIGHT;
+    m_device.CurrentFrame = m_currentFrameIndex;
 
     m_renderContext.hasSceneChanged = false;
 }

--- a/Internal/Vulkan/Renderer/Renderers/RenderingSystem.hpp
+++ b/Internal/Vulkan/Renderer/Renderers/RenderingSystem.hpp
@@ -21,6 +21,7 @@
 #include "Vulkan/VulkanCore/Synchronization/VTimelineSemaphore.hpp"
 
 namespace VulkanCore {
+class VTimelineSemaphore2;
 class VDescriptorLayoutCache;
 }
 namespace ApplicationCore {
@@ -77,10 +78,12 @@ class RenderingSystem
                     VEditor::UIContext&                  uiContext);
 
     void Init();
+    void CanStartRecording();
     void Render(ApplicationCore::ApplicationState& applicationState);
     void Update(ApplicationCore::ApplicationState& applicationState);
     void PostRender();
     void Destroy();
+    VulkanCore::VTimelineSemaphore2& GetTimelineSemaphore();
 
     ForwardRenderer&            GetSceneRenderer() { return *m_forwardRenderer; };
     VulkanUtils::RenderContext* GetRenderContext() { return &m_renderContext; }
@@ -109,10 +112,11 @@ class RenderingSystem
     std::unique_ptr<VulkanCore::VCommandPool>                m_renderingCommandPool;
     std::vector<std::unique_ptr<VulkanCore::VCommandBuffer>> m_renderingCommandBuffers;
 
+
     // Synchronization
     std::vector<std::unique_ptr<VulkanCore::VSyncPrimitive<vk::Semaphore>>> m_imageAvailableSemaphores;
     std::vector<std::unique_ptr<VulkanCore::VSyncPrimitive<vk::Semaphore>>> m_ableToPresentSemaphore;
-    std::vector<std::unique_ptr<VulkanCore::VTimelineSemaphore>>            m_frameTimeLine;
+    std::vector<std::unique_ptr<VulkanCore::VTimelineSemaphore2>>            m_frameTimeLine;
 
 
     // Render context

--- a/Internal/Vulkan/Renderer/Renderers/RenderingSystem.hpp
+++ b/Internal/Vulkan/Renderer/Renderers/RenderingSystem.hpp
@@ -78,7 +78,8 @@ class RenderingSystem
 
     void Init();
     void Render(ApplicationCore::ApplicationState& applicationState);
-    void Update();
+    void Update(ApplicationCore::ApplicationState& applicationState);
+    void PostRender();
     void Destroy();
 
     ForwardRenderer&            GetSceneRenderer() { return *m_forwardRenderer; };
@@ -111,8 +112,7 @@ class RenderingSystem
     // Synchronization
     std::vector<std::unique_ptr<VulkanCore::VSyncPrimitive<vk::Semaphore>>> m_imageAvailableSemaphores;
     std::vector<std::unique_ptr<VulkanCore::VSyncPrimitive<vk::Semaphore>>> m_ableToPresentSemaphore;
-    std::vector<std::unique_ptr<VulkanCore::VTimelineSemaphore>>            m_renderingTimeLine;
-    VulkanCore::VTimelineSemaphore&                                         m_transferSemapohore;
+    std::vector<std::unique_ptr<VulkanCore::VTimelineSemaphore>>            m_frameTimeLine;
 
 
     // Render context
@@ -125,6 +125,7 @@ class RenderingSystem
     uint32_t m_currentFrameIndex      = 0;
     uint64_t m_frameCount             = 0;
     uint64_t m_accumulatedFramesCount = 0;
+    std::pair<vk::Result, uint32_t> m_acquiredImage;
     bool     m_isRayTracing           = false;
 
     VulkanCore::VDescriptorLayoutCache& m_descLayoutCache;

--- a/Internal/Vulkan/Renderer/Renderers/UserInterfaceRenderer.cpp
+++ b/Internal/Vulkan/Renderer/Renderers/UserInterfaceRenderer.cpp
@@ -77,7 +77,7 @@ void UserInterfaceRenderer::Render(int currentFrameIndex, uint32_t swapChainImag
     cmdB.endRendering();
 
     barrierPosition = {vk::PipelineStageFlagBits2::eColorAttachmentOutput,
-                                                  vk::AccessFlagBits2::eColorAttachmentWrite};
+                                                  vk::AccessFlagBits2::eColorAttachmentWrite, vk::PipelineStageFlagBits2};
     VulkanUtils::PlaceImageMemoryBarrier2(m_renderTarget->GetSwapChainImage(swapChainImageIndex), cmdBuffer,
                                           vk::ImageLayout::eAttachmentOptimalKHR, vk::ImageLayout::ePresentSrcKHR, barrierPosition);
 

--- a/Internal/Vulkan/Renderer/Renderers/UserInterfaceRenderer.cpp
+++ b/Internal/Vulkan/Renderer/Renderers/UserInterfaceRenderer.cpp
@@ -90,7 +90,6 @@ void UserInterfaceRenderer::Render(int currentFrameIndex, uint32_t swapChainImag
     //assert(presentResult == vk::Result::eSuccess || result == vk::Result::eSuboptimalKHR);
 }
 void UserInterfaceRenderer::Present(uint32_t                        swapChainImageIndex,
-                                    VulkanCore::VTimelineSemaphore& renderingTimeLine,
                                     const vk::Semaphore&            ableToPresentSemaphore)
 {
     //===========================

--- a/Internal/Vulkan/Renderer/Renderers/UserInterfaceRenderer.cpp
+++ b/Internal/Vulkan/Renderer/Renderers/UserInterfaceRenderer.cpp
@@ -77,7 +77,8 @@ void UserInterfaceRenderer::Render(int currentFrameIndex, uint32_t swapChainImag
     cmdB.endRendering();
 
     barrierPosition = {vk::PipelineStageFlagBits2::eColorAttachmentOutput,
-                                                  vk::AccessFlagBits2::eColorAttachmentWrite, vk::PipelineStageFlagBits2};
+                                                  vk::AccessFlagBits2::eColorAttachmentWrite, vk::PipelineStageFlagBits2::eColorAttachmentOutput, vk::AccessFlagBits2::eColorAttachmentRead};
+
     VulkanUtils::PlaceImageMemoryBarrier2(m_renderTarget->GetSwapChainImage(swapChainImageIndex), cmdBuffer,
                                           vk::ImageLayout::eAttachmentOptimalKHR, vk::ImageLayout::ePresentSrcKHR, barrierPosition);
 

--- a/Internal/Vulkan/Renderer/Renderers/UserInterfaceRenderer.cpp
+++ b/Internal/Vulkan/Renderer/Renderers/UserInterfaceRenderer.cpp
@@ -96,6 +96,7 @@ void UserInterfaceRenderer::Present(uint32_t                        swapChainIma
     //===========================
     // PRESENT TO SCREEN
     //===========================
+
     vk::PresentInfoKHR presentInfo;
     //auto next = renderingTimeLine.GetTimeLineSemaphoreSubmitInfo(4, 8);
     //presentInfo.pNext = &next;

--- a/Internal/Vulkan/Renderer/Renderers/UserInterfaceRenderer.hpp
+++ b/Internal/Vulkan/Renderer/Renderers/UserInterfaceRenderer.hpp
@@ -45,7 +45,7 @@ class UserInterfaceRenderer
     explicit UserInterfaceRenderer(const VulkanCore::VDevice& device, const VulkanCore::VSwapChain& swapChain, VEditor::UIContext& uiContext);
 
     void Render(int currentFrameIndex,uint32_t swapChainImageIndex, VulkanCore::VCommandBuffer& cmdBuffer);
-    void Present(uint32_t swapChainImageIndex,VulkanCore::VTimelineSemaphore& renderingTimeLine,  const vk::Semaphore& ableToPresentSemaphore);
+    void Present(uint32_t swapChainImageIndex, const vk::Semaphore& ableToPresentSemaphore);
 
     RenderTarget2& GetRenderTarget() const { return *m_renderTarget; };
 

--- a/Internal/Vulkan/Utils/TransferOperationsManager/VTransferOperationsManager.cpp
+++ b/Internal/Vulkan/Utils/TransferOperationsManager/VTransferOperationsManager.cpp
@@ -9,6 +9,7 @@
 #include "Vulkan/VulkanCore/Buffer/VBuffer.hpp"
 #include "Vulkan/VulkanCore/CommandBuffer/VCommandBuffer.hpp"
 #include "Vulkan/VulkanCore/Synchronization/VTimelineSemaphore.hpp"
+#include "Vulkan/VulkanCore/Synchronization/VTimelineSemaphore2.hpp"
 
 namespace VulkanUtils {
 VTransferOperationsManager::VTransferOperationsManager(const VulkanCore::VDevice& device)
@@ -36,11 +37,11 @@ void VTransferOperationsManager::StartRecording()
     }
 }
 
-void VTransferOperationsManager::UpdateGPU(VulkanCore::VTimelineSemaphore& frameSemaphore)
+void VTransferOperationsManager::UpdateGPU(VulkanCore::VTimelineSemaphore2& frameSemaphore)
 {
     vk::PipelineStageFlags2 signalStages = vk::PipelineStageFlagBits2::eAllCommands;
 
-    std::vector<vk::SemaphoreSubmitInfo> signalSubmit = {frameSemaphore.GetSemaphoreSignalSubmitInfo(6, signalStages)};
+    std::vector<vk::SemaphoreSubmitInfo> signalSubmit = {frameSemaphore.GetSemaphoreSignalSubmitInfo(EFrameStages::TransferFinish, signalStages)};
 
     /**
      * Submits all the transfer work, like copyes as stuff, and only signals once it is finished it does not have to wait for any other semaphore
@@ -52,8 +53,10 @@ void VTransferOperationsManager::UpdateGPU(VulkanCore::VTimelineSemaphore& frame
 
 void VTransferOperationsManager::UpdateGPUWaitCPU(VulkanCore::VTimelineSemaphore& frameSemaphore, bool startRecording)
 {
-    UpdateGPU(frameSemaphore);
-    frameSemaphore.CpuWaitIdle(2);
+    //pdateGPU(frameSemaphore);
+    //frameSemaphore.CpuWaitIdle(9);
+    //frameSemaphore.Reset();
+    //frameSemaphore.CpuSignal(8);
     m_commandBuffer[m_device.CurrentFrame]->Reset();
 
     if(startRecording)

--- a/Internal/Vulkan/Utils/TransferOperationsManager/VTransferOperationsManager.cpp
+++ b/Internal/Vulkan/Utils/TransferOperationsManager/VTransferOperationsManager.cpp
@@ -25,15 +25,15 @@ VTransferOperationsManager::VTransferOperationsManager(const VulkanCore::VDevice
 VulkanCore::VCommandBuffer& VTransferOperationsManager::GetCommandBuffer()
 {
     m_hasPandingWork = true;
-    return *m_commandBuffer[m_device.CurrentFrame];
+    return *m_commandBuffer[m_device.CurrentFrameInFlight];
 }
 
 void VTransferOperationsManager::StartRecording()
 {
     m_hasPandingWork = true;
-    if(!m_commandBuffer[m_device.CurrentFrame]->GetIsRecording())
+    if(!m_commandBuffer[m_device.CurrentFrameInFlight]->GetIsRecording())
     {
-        m_commandBuffer[m_device.CurrentFrame]->BeginRecording();
+        m_commandBuffer[m_device.CurrentFrameInFlight]->BeginRecording();
     }
 }
 
@@ -46,7 +46,7 @@ void VTransferOperationsManager::UpdateGPU(VulkanCore::VTimelineSemaphore2& fram
     /**
      * Submits all the transfer work, like copyes as stuff, and only signals once it is finished it does not have to wait for any other semaphore
      */
-    m_commandBuffer[m_device.CurrentFrame]->EndAndFlush2(m_device.GetTransferQueue(), signalSubmit, {});
+    m_commandBuffer[m_device.CurrentFrameInFlight]->EndAndFlush2(m_device.GetTransferQueue(), signalSubmit, {});
 
     m_hasPandingWork = false;
 }
@@ -57,7 +57,7 @@ void VTransferOperationsManager::UpdateGPUWaitCPU(VulkanCore::VTimelineSemaphore
     //frameSemaphore.CpuWaitIdle(9);
     //frameSemaphore.Reset();
     //frameSemaphore.CpuSignal(8);
-    m_commandBuffer[m_device.CurrentFrame]->Reset();
+    m_commandBuffer[m_device.CurrentFrameInFlight]->Reset();
 
     if(startRecording)
     {

--- a/Internal/Vulkan/Utils/TransferOperationsManager/VTransferOperationsManager.cpp
+++ b/Internal/Vulkan/Utils/TransferOperationsManager/VTransferOperationsManager.cpp
@@ -37,16 +37,14 @@ void VTransferOperationsManager::UpdateGPU()
 {
     if(m_hasPandingWork)
     {
-        vk::PipelineStageFlags2 waitStages =
-            vk::PipelineStageFlagBits2::eVertexInput | vk::PipelineStageFlagBits2::eFragmentShader |
-            vk::PipelineStageFlagBits2::eEarlyFragmentTests | vk::PipelineStageFlagBits2::eCopy | vk::PipelineStageFlagBits2::eNone ;
+        vk::PipelineStageFlags2 signalStages = vk::PipelineStageFlagBits2::eTransfer | vk::PipelineStageFlagBits2::eCopy | vk::PipelineStageFlagBits2::eNone;
 
-        vk::PipelineStageFlags2 signalStages = vk::PipelineStageFlagBits2::eTransfer | vk::PipelineStageFlagBits2::eCopy;
+        std::vector<vk::SemaphoreSubmitInfo> signalSubmit = {m_transferTimeline->GetSemaphoreSignalSubmitInfo(2, signalStages)} ;
 
-        auto waitSubmit = m_transferTimeline->GetSemaphoreWaitSubmitInfo(0, waitStages);
-        auto signalSubmit = m_transferTimeline->GetSemaphoreSignalSubmitInfo(2, signalStages) ;
-
-        m_commandBuffer->EndAndFlush2(m_device.GetTransferQueue(), signalSubmit, waitSubmit);
+        /**
+         * Submits all the transfer work, like copyes as stuff, and only signals once it is finished it does not have to wait for any other semaphore
+         */
+        m_commandBuffer->EndAndFlush2(m_device.GetTransferQueue(), signalSubmit, {});
 
         m_hasPandingWork = false;
     }

--- a/Internal/Vulkan/Utils/TransferOperationsManager/VTransferOperationsManager.hpp
+++ b/Internal/Vulkan/Utils/TransferOperationsManager/VTransferOperationsManager.hpp
@@ -31,15 +31,13 @@ class VTransferOperationsManager
 
     VulkanCore::VCommandBuffer& GetCommandBuffer();
     void                        StartRecording();
-    void                        UpdateGPU();
-    void                        UpdateGPUWaitCPU(bool startRecording = false);
+    void                        UpdateGPU(VulkanCore::VTimelineSemaphore& frameSemaphore);
+    void                        UpdateGPUWaitCPU(VulkanCore::VTimelineSemaphore& frameSemaphore ,bool startRecording = false);
 
     void ClearResources();
 
     void DestroyBuffer(VkBuffer& buffer, VmaAllocation& vmaAllocation);
     void DestroyBuffer(VulkanCore::VBuffer& vBuffer, bool isStaging = false);
-
-    VulkanCore::VTimelineSemaphore& GetTransferSemaphore() const { return *m_transferTimeline; }
 
     void Destroy();
 
@@ -47,7 +45,6 @@ class VTransferOperationsManager
     bool                                            m_hasPandingWork = false;
     const VulkanCore::VDevice&                      m_device;
     std::unique_ptr<VulkanCore::VCommandBuffer>     m_commandBuffer;
-    std::unique_ptr<VulkanCore::VTimelineSemaphore> m_transferTimeline;
 
     std::vector<std::pair<VkBuffer, VmaAllocation>>    m_clearBuffersVKVMA;
     std::vector<std::pair<bool, VulkanCore::VBuffer*>> m_clearVBuffers;

--- a/Internal/Vulkan/Utils/TransferOperationsManager/VTransferOperationsManager.hpp
+++ b/Internal/Vulkan/Utils/TransferOperationsManager/VTransferOperationsManager.hpp
@@ -32,7 +32,7 @@ class VTransferOperationsManager
     VulkanCore::VCommandBuffer& GetCommandBuffer();
     void                        StartRecording();
     void                        UpdateGPU(VulkanCore::VTimelineSemaphore& frameSemaphore);
-    void                        UpdateGPUWaitCPU(VulkanCore::VTimelineSemaphore& frameSemaphore ,bool startRecording = false);
+    void UpdateGPUWaitCPU(VulkanCore::VTimelineSemaphore& frameSemaphore, bool startRecording = false);
 
     void ClearResources();
 
@@ -42,9 +42,9 @@ class VTransferOperationsManager
     void Destroy();
 
   private:
-    bool                                            m_hasPandingWork = false;
-    const VulkanCore::VDevice&                      m_device;
-    std::unique_ptr<VulkanCore::VCommandBuffer>     m_commandBuffer;
+    bool                                                     m_hasPandingWork = false;
+    const VulkanCore::VDevice&                               m_device;
+    std::vector<std::unique_ptr<VulkanCore::VCommandBuffer>> m_commandBuffer;
 
     std::vector<std::pair<VkBuffer, VmaAllocation>>    m_clearBuffersVKVMA;
     std::vector<std::pair<bool, VulkanCore::VBuffer*>> m_clearVBuffers;

--- a/Internal/Vulkan/Utils/TransferOperationsManager/VTransferOperationsManager.hpp
+++ b/Internal/Vulkan/Utils/TransferOperationsManager/VTransferOperationsManager.hpp
@@ -10,6 +10,7 @@
 #include "Application/Structs/ApplicationStructs.hpp"
 
 namespace VulkanCore {
+class VTimelineSemaphore2;
 class VBuffer;
 class VTimelineSemaphore;
 class VCommandBuffer;
@@ -31,7 +32,7 @@ class VTransferOperationsManager
 
     VulkanCore::VCommandBuffer& GetCommandBuffer();
     void                        StartRecording();
-    void                        UpdateGPU(VulkanCore::VTimelineSemaphore& frameSemaphore);
+    void                        UpdateGPU(VulkanCore::VTimelineSemaphore2& frameSemaphore);
     void UpdateGPUWaitCPU(VulkanCore::VTimelineSemaphore& frameSemaphore, bool startRecording = false);
 
     void ClearResources();

--- a/Internal/Vulkan/Utils/VEnvLightGenerator/VEnvLightGenerator.cpp
+++ b/Internal/Vulkan/Utils/VEnvLightGenerator/VEnvLightGenerator.cpp
@@ -24,6 +24,9 @@
 #include "Vulkan/VulkanCore/VImage/VImage2.hpp"
 
 
+namespace VulkanCore {
+class VTimelineSemaphore2;
+}
 VulkanUtils::VEnvLightGenerator::VEnvLightGenerator(const VulkanCore::VDevice& device, VulkanCore::VDescriptorLayoutCache& descLayoutCache)
     : m_device(device)
     , m_descLayoutChache(descLayoutCache)
@@ -174,7 +177,7 @@ VulkanCore::VImage2* VulkanUtils::VEnvLightGenerator::GetPrefilterMapRaw()
 
 void VulkanUtils::VEnvLightGenerator::Generate(uint32_t                             currentFrame,
                                                std::shared_ptr<VulkanCore::VImage2> envMap,
-                                               VulkanCore::VTimelineSemaphore&      renderingSemaphore)
+                                               VulkanCore::VTimelineSemaphore2&      renderingSemaphore)
 {
     m_currentFrame = currentFrame;
 
@@ -207,7 +210,7 @@ void VulkanUtils::VEnvLightGenerator::Generate(uint32_t                         
 // CUBE MAP GENERATION
 //==================================
 void VulkanUtils::VEnvLightGenerator::HDRToCubeMap(std::shared_ptr<VulkanCore::VImage2> envMap,
-                                                   VulkanCore::VTimelineSemaphore&      renderingSemaphore)
+                                                   VulkanCore::VTimelineSemaphore2&      renderingSemaphore)
 {
 
     {
@@ -346,7 +349,7 @@ void VulkanUtils::VEnvLightGenerator::HDRToCubeMap(std::shared_ptr<VulkanCore::V
 // IRRADIANCE GENERATION
 //==================================
 void VulkanUtils::VEnvLightGenerator::CubeMapToIrradiance(std::shared_ptr<VulkanCore::VImage2> envMap,
-                                                          VulkanCore::VTimelineSemaphore&      renderingSemaphore)
+                                                          VulkanCore::VTimelineSemaphore2&      renderingSemaphore)
 {
     {
 
@@ -467,7 +470,7 @@ void VulkanUtils::VEnvLightGenerator::CubeMapToIrradiance(std::shared_ptr<Vulkan
 // PREFILTER MAP
 //=====================================
 void VulkanUtils::VEnvLightGenerator::CubeMapToPrefilter(std::shared_ptr<VulkanCore::VImage2> envMap,
-                                                         VulkanCore::VTimelineSemaphore&      renderingSemaphore)
+                                                         VulkanCore::VTimelineSemaphore2&      renderingSemaphore)
 {
     VulkanCore::VTimelineSemaphore envGenerationSemaphore(m_device);
     const vk::Format               format     = vk::Format::eR16G16B16A16Sfloat;

--- a/Internal/Vulkan/Utils/VEnvLightGenerator/VEnvLightGenerator.hpp
+++ b/Internal/Vulkan/Utils/VEnvLightGenerator/VEnvLightGenerator.hpp
@@ -16,6 +16,7 @@
 #include "Vulkan/VulkanCore/Synchronization/VTimelineSemaphore.hpp"
 
 namespace VulkanCore {
+class VTimelineSemaphore2;
 class VDescriptorLayoutCache;
 }
 namespace VulkanCore {
@@ -69,11 +70,11 @@ class VEnvLightGenerator
 
     VulkanCore::VImage2* GetPrefilterMapRaw();
 
-    void Generate(uint32_t m_currentFrame, std::shared_ptr<VulkanCore::VImage2> envMap, VulkanCore::VTimelineSemaphore& renderingSemaphore);
+    void Generate(uint32_t m_currentFrame, std::shared_ptr<VulkanCore::VImage2> envMap, VulkanCore::VTimelineSemaphore2& renderingSemaphore);
 
-    void HDRToCubeMap(std::shared_ptr<VulkanCore::VImage2> envMap, VulkanCore::VTimelineSemaphore& renderingSemaphore);
-    void CubeMapToIrradiance(std::shared_ptr<VulkanCore::VImage2> envMap, VulkanCore::VTimelineSemaphore& renderingSemaphore);
-    void CubeMapToPrefilter(std::shared_ptr<VulkanCore::VImage2> envMap, VulkanCore::VTimelineSemaphore& renderingSemaphore);
+    void HDRToCubeMap(std::shared_ptr<VulkanCore::VImage2> envMap, VulkanCore::VTimelineSemaphore2& renderingSemaphore);
+    void CubeMapToIrradiance(std::shared_ptr<VulkanCore::VImage2> envMap, VulkanCore::VTimelineSemaphore2& renderingSemaphore);
+    void CubeMapToPrefilter(std::shared_ptr<VulkanCore::VImage2> envMap, VulkanCore::VTimelineSemaphore2& renderingSemaphore);
 
     void Destroy();
 

--- a/Internal/Vulkan/VulkanCore/CommandBuffer/VCommandBuffer.cpp
+++ b/Internal/Vulkan/VulkanCore/CommandBuffer/VCommandBuffer.cpp
@@ -141,8 +141,10 @@ void VCommandBuffer::EndAndFlush2(const vk::Queue&                            qu
     submitInfo.signalSemaphoreInfoCount = pSignalSemaphores.size();
     submitInfo.pSignalSemaphoreInfos = pSignalSemaphores.data();
 
-    submitInfo.waitSemaphoreInfoCount = pWaitSemaphores.size();
-    submitInfo.pWaitSemaphoreInfos = pWaitSemaphores.data();
+    if (!pWaitSemaphores.empty()) {
+        submitInfo.waitSemaphoreInfoCount = pWaitSemaphores.size();
+        submitInfo.pWaitSemaphoreInfos = pWaitSemaphores.data();
+    }
 
     auto queueResult = queue.submit2(1, &submitInfo, nullptr);
 

--- a/Internal/Vulkan/VulkanCore/CommandBuffer/VCommandBuffer.cpp
+++ b/Internal/Vulkan/VulkanCore/CommandBuffer/VCommandBuffer.cpp
@@ -159,6 +159,7 @@ void VCommandBuffer::EndAndFlush(const vk::Queue&                     queue,
 {
     std::lock_guard<std::mutex> lock(m_device.DeviceMutex);
     EndRecording();
+
     vk::SubmitInfo submitInfo;
     submitInfo.commandBufferCount = 1;
     submitInfo.pCommandBuffers    = &m_commandBuffer;

--- a/Internal/Vulkan/VulkanCore/CommandBuffer/VCommandBuffer.hpp
+++ b/Internal/Vulkan/VulkanCore/CommandBuffer/VCommandBuffer.hpp
@@ -28,8 +28,8 @@ class VCommandBuffer : public VObject
     void EndAndFlush(const vk::Queue& queue);
     void EndAndFlush(const vk::Queue& queue, const vk::Fence& fence);
     void EndAndFlush(const vk::Queue& queue, vk::Semaphore& timeline, VkTimelineSemaphoreSubmitInfo& timelineInfo, vk::PipelineStageFlags* pWaitStages);
-    void EndAndFlush2(const vk::Queue& queue, const vk::SemaphoreSubmitInfo& pSignalSemaphores,const vk::SemaphoreSubmitInfo& pWaitSemaphores);
-    void EndAndFlush2(const vk::Queue& queue, const std::vector<vk::SemaphoreSubmitInfo>& pSignalSemaphores,const std::vector<vk::SemaphoreSubmitInfo>& pWaitSemaphores);
+    void EndAndFlush2(const vk::Queue& queue,const vk::SemaphoreSubmitInfo& pSignalSemaphores,const vk::SemaphoreSubmitInfo& pWaitSemaphores);
+    void EndAndFlush2(const vk::Queue& queue, const std::vector<vk::SemaphoreSubmitInfo>& pSignalSemaphores, const  std::vector<vk::SemaphoreSubmitInfo>& pWaitSemaphores);
 
     void EndAndFlush(const vk::Queue&                     queue,
                      std::vector<vk::Semaphore>&          waitSemaphores,

--- a/Internal/Vulkan/VulkanCore/Device/VDevice.cpp
+++ b/Internal/Vulkan/VulkanCore/Device/VDevice.cpp
@@ -138,7 +138,6 @@ VulkanCore::VDevice::VDevice(const VulkanCore::VulkanInstance& instance)
     RetreiveDepthFormat();
 
     m_transferOpsManager = std::make_unique<VulkanUtils::VTransferOperationsManager>(*this);
-    m_transferOpsManager->StartRecording();
     m_meshDataManager    = std::make_unique<MeshDatatManager>(*this);
     m_descriptorAllocator = std::make_unique<VulkanCore::VDescriptorAllocator>(*this);
 }

--- a/Internal/Vulkan/VulkanCore/Device/VDevice.hpp
+++ b/Internal/Vulkan/VulkanCore/Device/VDevice.hpp
@@ -15,6 +15,9 @@
 #include "Vulkan/Utils/VMeshDataManager/MeshDataManager.hpp"
 
 namespace VulkanCore {
+class VTimelineSemaphore;
+}
+namespace VulkanCore {
 class VDescriptorAllocator;
 }
 namespace VulkanUtils {
@@ -68,7 +71,7 @@ class VDevice : public VObject
     const vk::Format&                        GetDepthFormat() const { return m_depthFormat; }
     const vk::SampleCountFlagBits            GetSampleCount() const { return m_sampleCount; }
     VmaTotalStatistics&                      GetDeviceStatistics() { return m_vmaStatistics; }
-    VulkanUtils::VTransferOperationsManager& GetTransferOpsManager() const  { return *m_transferOpsManager;  }
+    VulkanUtils::VTransferOperationsManager& GetTransferOpsManager() const { return *m_transferOpsManager; }
     VulkanCore::VDescriptorAllocator&        GetDescriptorAllocator() const { return *m_descriptorAllocator; }
     //----------------------------------------------------------------------------------------
 
@@ -98,10 +101,11 @@ class VDevice : public VObject
     vk::SampleCountFlagBits m_sampleCount;
 
     std::array<std::unique_ptr<VulkanCore::VCommandPool>, GlobalVariables::MAX_THREADS> m_transferCommandPool;
-    std::unique_ptr<VulkanCore::VCommandPool>                m_transferCommandPoolForSingleThread;
-    std::unique_ptr<VulkanUtils::VTransferOperationsManager> m_transferOpsManager;
-    std::unique_ptr<MeshDatatManager>                        m_meshDataManager;
-    std::unique_ptr<VulkanCore::VDescriptorAllocator>        m_descriptorAllocator;
+    std::unique_ptr<VulkanCore::VCommandPool>                    m_transferCommandPoolForSingleThread;
+    std::unique_ptr<VulkanUtils::VTransferOperationsManager>     m_transferOpsManager;
+    std::unique_ptr<MeshDatatManager>                            m_meshDataManager;
+    std::unique_ptr<VulkanCore::VDescriptorAllocator>            m_descriptorAllocator;
+    std::vector<std::unique_ptr<VulkanCore::VTimelineSemaphore>> m_frameSemaphore;
 
     VQueueFamilyIndices m_queueFamilyIndices;
 

--- a/Internal/Vulkan/VulkanCore/Device/VDevice.hpp
+++ b/Internal/Vulkan/VulkanCore/Device/VDevice.hpp
@@ -88,6 +88,8 @@ class VDevice : public VObject
 
     vk::detail::DispatchLoaderDynamic DispatchLoader;
 
+    mutable uint32_t CurrentFrame = 0;
+
   private:
     vk::PhysicalDevice m_physicalDevice;
     vk::Device         m_device;  //logical device

--- a/Internal/Vulkan/VulkanCore/Device/VDevice.hpp
+++ b/Internal/Vulkan/VulkanCore/Device/VDevice.hpp
@@ -88,8 +88,8 @@ class VDevice : public VObject
 
     vk::detail::DispatchLoaderDynamic DispatchLoader;
 
-    mutable uint32_t CurrentFrame = 0;
-
+    mutable uint64_t CurrentFrame = 0;
+    mutable uint32_t CurrentFrameInFlight = 0;
   private:
     vk::PhysicalDevice m_physicalDevice;
     vk::Device         m_device;  //logical device

--- a/Internal/Vulkan/VulkanCore/Synchronization/VTimelineSemaphore.cpp
+++ b/Internal/Vulkan/VulkanCore/Synchronization/VTimelineSemaphore.cpp
@@ -40,7 +40,7 @@ vk::TimelineSemaphoreSubmitInfo VTimelineSemaphore::GetTimeLineSemaphoreSubmitIn
     submitInfo.pSignalSemaphoreValues    = &m_currentSignal;
     return submitInfo;
 }
-vk::SemaphoreSubmitInfo VTimelineSemaphore::GetSemaphoreWaitSubmitInfo(uint64_t waitValue, vk::PipelineStageFlags2& waitStages)
+vk::SemaphoreSubmitInfo VTimelineSemaphore::GetSemaphoreWaitSubmitInfo(uint64_t waitValue, vk::PipelineStageFlags2 waitStages)
 {
     m_waitHistory.emplace_back(m_offset + waitValue);
 
@@ -54,7 +54,7 @@ vk::SemaphoreSubmitInfo VTimelineSemaphore::GetSemaphoreWaitSubmitInfo(uint64_t 
     return waitSubmitInfo;
 }
 
-vk::SemaphoreSubmitInfo VTimelineSemaphore::GetSemaphoreSignalSubmitInfo(uint64_t signalValue, vk::PipelineStageFlags2& signalStages)
+vk::SemaphoreSubmitInfo VTimelineSemaphore::GetSemaphoreSignalSubmitInfo(uint64_t signalValue, vk::PipelineStageFlags2 signalStages)
 {
 
     m_currentSignal = m_offset + signalValue;

--- a/Internal/Vulkan/VulkanCore/Synchronization/VTimelineSemaphore.hpp
+++ b/Internal/Vulkan/VulkanCore/Synchronization/VTimelineSemaphore.hpp
@@ -18,9 +18,9 @@ class VTimelineSemaphore : public VObject
     explicit VTimelineSemaphore(const VulkanCore::VDevice& device, uint64_t initialValue = 0);
 
     vk::TimelineSemaphoreSubmitInfo GetTimeLineSemaphoreSubmitInfo(uint64_t waitValue, uint64_t signalValue);
-    vk::SemaphoreSubmitInfo GetSemaphoreWaitSubmitInfo(uint64_t waitValue,vk::PipelineStageFlags2 waitStages);
+    vk::SemaphoreSubmitInfo         GetSemaphoreWaitSubmitInfo(uint64_t waitValue, vk::PipelineStageFlags2 waitStages);
     vk::SemaphoreSubmitInfo GetSemaphoreSignalSubmitInfo(uint64_t signalValue, vk::PipelineStageFlags2 signalStages);
-    uint64_t                        GetSemaphoreValue();
+    uint64_t                GetSemaphoreValue();
 
     void CpuSignal(uint64_t signalValue);
     void CpuWaitIdle(uint64_t waitValue);

--- a/Internal/Vulkan/VulkanCore/Synchronization/VTimelineSemaphore.hpp
+++ b/Internal/Vulkan/VulkanCore/Synchronization/VTimelineSemaphore.hpp
@@ -44,8 +44,6 @@ class VTimelineSemaphore : public VObject
 
     vk::Semaphore m_semaphore;
 
-    //uint64_t m_currentValue = 0;
-
     uint64_t m_offset = 0;
 };
 

--- a/Internal/Vulkan/VulkanCore/Synchronization/VTimelineSemaphore.hpp
+++ b/Internal/Vulkan/VulkanCore/Synchronization/VTimelineSemaphore.hpp
@@ -18,8 +18,8 @@ class VTimelineSemaphore : public VObject
     explicit VTimelineSemaphore(const VulkanCore::VDevice& device, uint64_t initialValue = 0);
 
     vk::TimelineSemaphoreSubmitInfo GetTimeLineSemaphoreSubmitInfo(uint64_t waitValue, uint64_t signalValue);
-    vk::SemaphoreSubmitInfo GetSemaphoreWaitSubmitInfo(uint64_t waitValue,vk::PipelineStageFlags2& waitStages);
-    vk::SemaphoreSubmitInfo GetSemaphoreSignalSubmitInfo(uint64_t signalValue, vk::PipelineStageFlags2& signalStages);
+    vk::SemaphoreSubmitInfo GetSemaphoreWaitSubmitInfo(uint64_t waitValue,vk::PipelineStageFlags2 waitStages);
+    vk::SemaphoreSubmitInfo GetSemaphoreSignalSubmitInfo(uint64_t signalValue, vk::PipelineStageFlags2 signalStages);
     uint64_t                        GetSemaphoreValue();
 
     void CpuSignal(uint64_t signalValue);

--- a/Internal/Vulkan/VulkanCore/Synchronization/VTimelineSemaphore2.cpp
+++ b/Internal/Vulkan/VulkanCore/Synchronization/VTimelineSemaphore2.cpp
@@ -1,0 +1,79 @@
+//
+// Created by wpsimon09 on 02/09/2025.
+//
+
+#include "VTimelineSemaphore2.hpp"
+
+#include "Vulkan/VulkanCore/Device/VDevice.hpp"
+
+namespace VulkanCore {
+VTimelineSemaphore2::VTimelineSemaphore2(const VulkanCore::VDevice& device, uint32_t maxStageValue)
+    : VObject()
+    , m_device(device)
+    , m_maxStageValue(maxStageValue)
+{
+    vk::SemaphoreTypeCreateInfo timelineInfo;
+    timelineInfo.pNext         = nullptr;
+    timelineInfo.semaphoreType = vk::SemaphoreType::eTimeline;
+    timelineInfo.initialValue  = 0;
+
+    vk::SemaphoreCreateInfo semaphoreInfo;
+    semaphoreInfo.pNext = &timelineInfo;
+    semaphoreInfo.flags = {};
+
+    m_semaphore = m_device.GetDevice().createSemaphore(semaphoreInfo);
+}
+vk::SemaphoreSubmitInfo VTimelineSemaphore2::GetSemaphoreWaitSubmitInfo(uint32_t stage, vk::PipelineStageFlags2 waitStages)
+{
+    vk::SemaphoreSubmitInfo waitSubmitInfo{};
+    waitSubmitInfo.semaphore = m_semaphore;
+    waitSubmitInfo.value     = GetStageValue(stage);
+    waitSubmitInfo.stageMask = waitStages;
+
+    return waitSubmitInfo;
+}
+
+vk::SemaphoreSubmitInfo VTimelineSemaphore2::GetSemaphoreSignalSubmitInfo(uint32_t stage, vk::PipelineStageFlags2 signalStages)
+{
+    vk::SemaphoreSubmitInfo signalSubmitInfo{};
+    signalSubmitInfo.semaphore = m_semaphore;
+    signalSubmitInfo.value     = GetStageValue(stage);
+    signalSubmitInfo.stageMask = signalStages;
+
+    return signalSubmitInfo;
+}
+void VTimelineSemaphore2::CpuSignal(uint32_t signalStage)
+{
+    vk::SemaphoreSignalInfo signalInfo;
+    signalInfo.pNext     = nullptr;
+    signalInfo.semaphore = m_semaphore;
+    signalInfo.value     = GetStageValue(signalStage);
+    m_device.GetDevice().signalSemaphore(signalInfo);
+}
+
+void VTimelineSemaphore2::CpuWaitIdle(uint32_t waitStage)
+{
+    const uint64_t value = GetStageValue(waitStage);
+
+    vk::SemaphoreWaitInfo waitInfo;
+    waitInfo.flags          = {};
+    waitInfo.semaphoreCount = 1;
+    waitInfo.pSemaphores    = &m_semaphore;
+    waitInfo.pValues        = &value;
+
+    while(m_device.GetDevice().waitSemaphores(waitInfo, UINT64_MAX) == vk::Result::eTimeout)
+        ;
+}
+
+
+uint32_t VTimelineSemaphore2::GetStageValue(uint32_t stage) const
+{
+    return (m_device.CurrentFrame * m_maxStageValue) + stage;
+}
+
+
+void VTimelineSemaphore2::Destroy()
+{
+    m_device.GetDevice().destroySemaphore(m_semaphore);
+}
+}  // namespace VulkanCore

--- a/Internal/Vulkan/VulkanCore/Synchronization/VTimelineSemaphore2.cpp
+++ b/Internal/Vulkan/VulkanCore/Synchronization/VTimelineSemaphore2.cpp
@@ -82,7 +82,7 @@ void VTimelineSemaphore2::CpuWaitIdle(uint32_t waitStage)
 
 uint32_t VTimelineSemaphore2::GetStageValue(uint32_t stage) const
 {
-    return (m_device.CurrentFrame * m_maxStageValue) + stage;
+    return (Frame * m_maxStageValue) + stage;
 }
 
 

--- a/Internal/Vulkan/VulkanCore/Synchronization/VTimelineSemaphore2.cpp
+++ b/Internal/Vulkan/VulkanCore/Synchronization/VTimelineSemaphore2.cpp
@@ -4,7 +4,11 @@
 
 #include "VTimelineSemaphore2.hpp"
 
+#include "simdjson.h"
+#include "Application/Logger/Logger.hpp"
 #include "Vulkan/VulkanCore/Device/VDevice.hpp"
+
+#include <iostream>
 
 namespace VulkanCore {
 VTimelineSemaphore2::VTimelineSemaphore2(const VulkanCore::VDevice& device, uint32_t maxStageValue)
@@ -30,6 +34,9 @@ vk::SemaphoreSubmitInfo VTimelineSemaphore2::GetSemaphoreWaitSubmitInfo(uint32_t
     waitSubmitInfo.value     = GetStageValue(stage);
     waitSubmitInfo.stageMask = waitStages;
 
+    std::cout<<"Waiting  for: " << waitSubmitInfo.value << std::endl;
+
+
     return waitSubmitInfo;
 }
 
@@ -40,6 +47,9 @@ vk::SemaphoreSubmitInfo VTimelineSemaphore2::GetSemaphoreSignalSubmitInfo(uint32
     signalSubmitInfo.value     = GetStageValue(stage);
     signalSubmitInfo.stageMask = signalStages;
 
+    std::cout<<"Signalling: " << signalSubmitInfo.value << std::endl;
+
+
     return signalSubmitInfo;
 }
 void VTimelineSemaphore2::CpuSignal(uint32_t signalStage)
@@ -49,6 +59,8 @@ void VTimelineSemaphore2::CpuSignal(uint32_t signalStage)
     signalInfo.semaphore = m_semaphore;
     signalInfo.value     = GetStageValue(signalStage);
     m_device.GetDevice().signalSemaphore(signalInfo);
+
+    std::cout<<"Signaling (from CPU) : " << signalInfo.value << std::endl;
 }
 
 void VTimelineSemaphore2::CpuWaitIdle(uint32_t waitStage)
@@ -60,6 +72,8 @@ void VTimelineSemaphore2::CpuWaitIdle(uint32_t waitStage)
     waitInfo.semaphoreCount = 1;
     waitInfo.pSemaphores    = &m_semaphore;
     waitInfo.pValues        = &value;
+
+    std::cout<<"Waiting (on CPU) for: " << value << std::endl;
 
     while(m_device.GetDevice().waitSemaphores(waitInfo, UINT64_MAX) == vk::Result::eTimeout)
         ;

--- a/Internal/Vulkan/VulkanCore/Synchronization/VTimelineSemaphore2.hpp
+++ b/Internal/Vulkan/VulkanCore/Synchronization/VTimelineSemaphore2.hpp
@@ -26,6 +26,8 @@ public:
 
   void Destroy() override;
 
+  uint64_t Frame = 0;
+
 private:
   uint32_t GetStageValue(uint32_t stage) const;
 

--- a/Internal/Vulkan/VulkanCore/Synchronization/VTimelineSemaphore2.hpp
+++ b/Internal/Vulkan/VulkanCore/Synchronization/VTimelineSemaphore2.hpp
@@ -19,7 +19,7 @@ public:
   vk::SemaphoreSubmitInfo         GetSemaphoreWaitSubmitInfo(uint32_t stage, vk::PipelineStageFlags2 waitStages);
   vk::SemaphoreSubmitInfo         GetSemaphoreSignalSubmitInfo(uint32_t stage, vk::PipelineStageFlags2 signalStages);
 
-  void CpuSignal(uint32_t signalStage);
+  void CpuSignal  (uint32_t signalStage);
   void CpuWaitIdle(uint32_t waitStage);
 
   void Reset();

--- a/Internal/Vulkan/VulkanCore/Synchronization/VTimelineSemaphore2.hpp
+++ b/Internal/Vulkan/VulkanCore/Synchronization/VTimelineSemaphore2.hpp
@@ -1,0 +1,40 @@
+//
+// Created by wpsimon09 on 02/09/2025.
+//
+
+#ifndef VULKAN_RTX_VTIMELINESEMAPHORE2_HPP
+#define VULKAN_RTX_VTIMELINESEMAPHORE2_HPP
+#include "VTimelineSemaphore.hpp"
+#include "Vulkan/Global/GlobalVulkanEnums.hpp"
+#include "Vulkan/VulkanCore/VObject.hpp"
+
+namespace VulkanCore {
+class VDevice;
+
+class VTimelineSemaphore2 : public VObject
+{
+public:
+  VTimelineSemaphore2(const VulkanCore::VDevice& device, uint32_t maxStages);
+
+  vk::SemaphoreSubmitInfo         GetSemaphoreWaitSubmitInfo(uint32_t stage, vk::PipelineStageFlags2 waitStages);
+  vk::SemaphoreSubmitInfo         GetSemaphoreSignalSubmitInfo(uint32_t stage, vk::PipelineStageFlags2 signalStages);
+
+  void CpuSignal(uint32_t signalStage);
+  void CpuWaitIdle(uint32_t waitStage);
+
+  void Reset();
+
+  void Destroy() override;
+
+private:
+  uint32_t GetStageValue(uint32_t stage) const;
+
+  const VulkanCore::VDevice& m_device;
+  vk::Semaphore m_semaphore;
+  uint64_t m_frame = 0;
+  uint32_t m_maxStageValue = 1;
+};
+
+}  // namespace VulkanCore
+
+#endif  //VULKAN_RTX_VTIMELINESEMAPHORE2_HPP

--- a/Internal/VulkanRtx.cpp
+++ b/Internal/VulkanRtx.cpp
@@ -77,6 +77,7 @@
 #include "Vulkan/Renderer/Renderers/RenderPass/LightPass.hpp"
 #include "Vulkan/Renderer/Renderers/RenderPass/PostProcessing.hpp"
 #include "Vulkan/VulkanCore/Buffer/VGrowableBuffer.hpp"
+#include "Vulkan/VulkanCore/Synchronization/VTimelineSemaphore2.hpp"
 
 
 Application::Application() = default;
@@ -141,14 +142,7 @@ void Application::Init()
 
     ApplicationCore::LoadClientSideConfig(*m_client, *m_uiContext);
 
-    //m_vulkanDevice->GetTransferOpsManager().UpdateGPUWaitCPU(true);
-    m_client->GetScene().Update();
     m_client->GetApplicationState().GetSceneUpdateFlags().rebuildAs = true;
-
-    //m_vulkanDevice->GetTransferOpsManager().UpdateGPUWaitCPU();
-
-    m_effectsLibrary->ConfigureDescriptorWrites(m_renderingSystem->GetSceneRenderer(), *m_uniformBufferManager, *m_rayTracingDataManager);
-
 }
 
 void Application::MainLoop()
@@ -183,6 +177,7 @@ void Application::Run()
 
 void Application::Update()
 {
+    m_renderingSystem->CanStartRecording();
     m_vulkanDevice->GetTransferOpsManager().StartRecording();
 
     //=========================
@@ -248,6 +243,7 @@ Application::~Application()
         }
         catch(std::exception& e)
         {
+
         }
     }
     m_vulkanDevice->GetDevice().waitIdle();

--- a/Internal/VulkanRtx.cpp
+++ b/Internal/VulkanRtx.cpp
@@ -116,6 +116,7 @@ void Application::Init()
     m_client->Init();
     m_uiContext = std::make_unique<VEditor::UIContext>(*m_vulkanDevice, *m_vulkanInstance, *m_windowManager, *m_client);
 
+
     m_renderingSystem = std::make_unique<Renderer::RenderingSystem>(*m_vulkanInstance, *m_vulkanDevice, *m_rayTracingDataManager,
                                                                     *m_uniformBufferManager, *m_effectsLibrary,
                                                                     *m_descriptorSetLayoutCache, *m_uiContext);
@@ -205,7 +206,6 @@ void Application::Update()
 
     m_client->GetAssetsManager().Sync();
 
-    m_renderingSystem->Update(m_client->GetApplicationState());
 }
 
 void Application::Render()
@@ -214,6 +214,8 @@ void Application::Render()
     m_client->Render(m_renderingSystem->GetRenderContext());
 
     m_editor->Render();
+
+    m_renderingSystem->Update(m_client->GetApplicationState());
 
     m_renderingSystem->Render(m_client->GetApplicationState());
 

--- a/Internal/VulkanRtx.cpp
+++ b/Internal/VulkanRtx.cpp
@@ -141,12 +141,11 @@ void Application::Init()
 
     ApplicationCore::LoadClientSideConfig(*m_client, *m_uiContext);
 
-    m_vulkanDevice->GetTransferOpsManager().UpdateGPUWaitCPU(true);
+    //m_vulkanDevice->GetTransferOpsManager().UpdateGPUWaitCPU(true);
     m_client->GetScene().Update();
-    auto inputs = m_client->GetScene().GetBLASInputs();
-    m_rayTracingDataManager->InitAs(inputs);
+    m_client->GetApplicationState().GetSceneUpdateFlags().rebuildAs = true;
 
-    m_vulkanDevice->GetTransferOpsManager().UpdateGPUWaitCPU();
+    //m_vulkanDevice->GetTransferOpsManager().UpdateGPUWaitCPU();
 
     m_effectsLibrary->ConfigureDescriptorWrites(m_renderingSystem->GetSceneRenderer(), *m_uniformBufferManager, *m_rayTracingDataManager);
 
@@ -208,11 +207,14 @@ void Application::Update()
     m_rayTracingDataManager->Update(m_client->GetScene());
 
     m_client->GetApplicationState().SetIsWindowResized(m_windowManager->GetHasResized());
+
+    m_client->GetAssetsManager().Sync();
+
+    m_renderingSystem->Update(m_client->GetApplicationState());
 }
 
 void Application::Render()
 {
-    m_client->GetAssetsManager().Sync();
 
     m_client->Render(m_renderingSystem->GetRenderContext());
 
@@ -220,14 +222,15 @@ void Application::Render()
 
     m_renderingSystem->Render(m_client->GetApplicationState());
 
-    m_renderingSystem->Update();
 }
 
 void Application::PostRender()
 {
+    m_renderingSystem->PostRender();
     m_vulkanDevice->GetTransferOpsManager().ClearResources();
     m_client->GetScene().Reset();
     m_client->GetApplicationState().Reset();
+
 }
 
 Application::~Application()

--- a/imgui.ini
+++ b/imgui.ini
@@ -95,8 +95,8 @@ Size=800,600
 Collapsed=0
 
 [Window][Index]
-Pos=0,22
-Size=1000,778
+Pos=0,0
+Size=1000,800
 Collapsed=0
 
 [Window][Scene graph]
@@ -120,8 +120,8 @@ Size=387,1109
 Collapsed=0
 
 [Window][ Scene view port]
-Pos=0,44
-Size=670,567
+Pos=0,22
+Size=1000,778
 Collapsed=0
 DockId=0x00000002,0
 
@@ -131,8 +131,8 @@ Size=410,410
 Collapsed=0
 
 [Window][ Details]
-Pos=672,356
-Size=328,444
+Pos=0,0
+Size=16,38
 Collapsed=0
 DockId=0x00000008,0
 
@@ -142,8 +142,8 @@ Size=397,550
 Collapsed=0
 
 [Window][ Rendering options]
-Pos=331,613
-Size=339,187
+Pos=0,0
+Size=16,38
 Collapsed=0
 DockId=0x00000004,1
 
@@ -168,14 +168,14 @@ Size=1009,256
 Collapsed=0
 
 [Window][ Console]
-Pos=0,613
-Size=329,187
+Pos=0,0
+Size=16,38
 Collapsed=0
 DockId=0x00000003,0
 
 [Window][ Scene graph]
-Pos=672,44
-Size=328,310
+Pos=0,0
+Size=30,38
 Collapsed=0
 DockId=0x00000007,0
 
@@ -200,8 +200,8 @@ Size=494,492
 Collapsed=0
 
 [Window][ ContentBrowser]
-Pos=331,613
-Size=339,187
+Pos=0,0
+Size=16,38
 Collapsed=0
 DockId=0x00000004,0
 
@@ -886,7 +886,7 @@ RefScale=16
 Column 0  Sort=0v
 
 [Docking][Data]
-DockSpace       ID=0x80E0A261 Window=0x5FDD4DE6 Pos=0,44 Size=1000,756 Split=X Selected=0x7DBD9211
+DockSpace       ID=0x80E0A261 Window=0x5FDD4DE6 Pos=0,22 Size=1000,778 Split=X Selected=0x7DBD9211
   DockNode      ID=0x00000005 Parent=0x80E0A261 SizeRef=1590,756 Split=Y
     DockNode    ID=0x00000002 Parent=0x00000005 SizeRef=1000,898 CentralNode=1 Selected=0x7DBD9211
     DockNode    ID=0x00000001 Parent=0x00000005 SizeRef=1000,187 Split=X Selected=0xEFDE7E8D

--- a/imgui.ini
+++ b/imgui.ini
@@ -96,7 +96,7 @@ Collapsed=0
 
 [Window][Index]
 Pos=0,22
-Size=1920,1109
+Size=1000,778
 Collapsed=0
 
 [Window][Scene graph]
@@ -121,7 +121,7 @@ Collapsed=0
 
 [Window][ Scene view port]
 Pos=0,44
-Size=1590,898
+Size=670,567
 Collapsed=0
 DockId=0x00000002,0
 
@@ -131,8 +131,8 @@ Size=410,410
 Collapsed=0
 
 [Window][ Details]
-Pos=1592,493
-Size=328,638
+Pos=672,356
+Size=328,444
 Collapsed=0
 DockId=0x00000008,0
 
@@ -142,8 +142,8 @@ Size=397,550
 Collapsed=0
 
 [Window][ Rendering options]
-Pos=784,944
-Size=806,187
+Pos=331,613
+Size=339,187
 Collapsed=0
 DockId=0x00000004,1
 
@@ -168,14 +168,14 @@ Size=1009,256
 Collapsed=0
 
 [Window][ Console]
-Pos=0,944
-Size=782,187
+Pos=0,613
+Size=329,187
 Collapsed=0
 DockId=0x00000003,0
 
 [Window][ Scene graph]
-Pos=1592,44
-Size=328,447
+Pos=672,44
+Size=328,310
 Collapsed=0
 DockId=0x00000007,0
 
@@ -200,8 +200,8 @@ Size=494,492
 Collapsed=0
 
 [Window][ ContentBrowser]
-Pos=784,944
-Size=806,187
+Pos=331,613
+Size=339,187
 Collapsed=0
 DockId=0x00000004,0
 
@@ -886,7 +886,7 @@ RefScale=16
 Column 0  Sort=0v
 
 [Docking][Data]
-DockSpace       ID=0x80E0A261 Window=0x5FDD4DE6 Pos=0,44 Size=1920,1087 Split=X Selected=0x7DBD9211
+DockSpace       ID=0x80E0A261 Window=0x5FDD4DE6 Pos=0,44 Size=1000,756 Split=X Selected=0x7DBD9211
   DockNode      ID=0x00000005 Parent=0x80E0A261 SizeRef=1590,756 Split=Y
     DockNode    ID=0x00000002 Parent=0x00000005 SizeRef=1000,898 CentralNode=1 Selected=0x7DBD9211
     DockNode    ID=0x00000001 Parent=0x00000005 SizeRef=1000,187 Split=X Selected=0xEFDE7E8D

--- a/imgui.ini
+++ b/imgui.ini
@@ -95,8 +95,8 @@ Size=800,600
 Collapsed=0
 
 [Window][Index]
-Pos=0,0
-Size=1000,800
+Pos=0,22
+Size=1000,778
 Collapsed=0
 
 [Window][Scene graph]
@@ -120,8 +120,8 @@ Size=387,1109
 Collapsed=0
 
 [Window][ Scene view port]
-Pos=0,22
-Size=1000,778
+Pos=0,44
+Size=670,567
 Collapsed=0
 DockId=0x00000002,0
 
@@ -131,8 +131,8 @@ Size=410,410
 Collapsed=0
 
 [Window][ Details]
-Pos=0,0
-Size=16,38
+Pos=672,356
+Size=328,444
 Collapsed=0
 DockId=0x00000008,0
 
@@ -142,8 +142,8 @@ Size=397,550
 Collapsed=0
 
 [Window][ Rendering options]
-Pos=0,0
-Size=16,38
+Pos=331,613
+Size=339,187
 Collapsed=0
 DockId=0x00000004,1
 
@@ -168,14 +168,14 @@ Size=1009,256
 Collapsed=0
 
 [Window][ Console]
-Pos=0,0
-Size=16,38
+Pos=0,613
+Size=329,187
 Collapsed=0
 DockId=0x00000003,0
 
 [Window][ Scene graph]
-Pos=0,0
-Size=30,38
+Pos=672,44
+Size=328,310
 Collapsed=0
 DockId=0x00000007,0
 
@@ -200,8 +200,8 @@ Size=494,492
 Collapsed=0
 
 [Window][ ContentBrowser]
-Pos=0,0
-Size=16,38
+Pos=331,613
+Size=339,187
 Collapsed=0
 DockId=0x00000004,0
 
@@ -886,7 +886,7 @@ RefScale=16
 Column 0  Sort=0v
 
 [Docking][Data]
-DockSpace       ID=0x80E0A261 Window=0x5FDD4DE6 Pos=0,22 Size=1000,778 Split=X Selected=0x7DBD9211
+DockSpace       ID=0x80E0A261 Window=0x5FDD4DE6 Pos=0,44 Size=1000,756 Split=X Selected=0x7DBD9211
   DockNode      ID=0x00000005 Parent=0x80E0A261 SizeRef=1590,756 Split=Y
     DockNode    ID=0x00000002 Parent=0x00000005 SizeRef=1000,898 CentralNode=1 Selected=0x7DBD9211
     DockNode    ID=0x00000001 Parent=0x00000005 SizeRef=1000,187 Split=X Selected=0xEFDE7E8D


### PR DESCRIPTION
Submits of transfer operations, image layout transitions and as builds are now handled throght dedicated submit and sync is now also much much clearer

Also used `vkCmdQueueSubmit2` function to combine time line and binary semaphores to the single coherent submit command. 

Lastly created `VTimelineSemaphore2` abstraction which is more closely reflecting of how time line semaphores should be used to sync different submits 